### PR TITLE
Amazon DynamoDB Storage backend for the Strands Agents SDK (TypeScript and Python)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Every change requires review from a maintainer. Branch protection on main is
+# configured to require CODEOWNERS review, so this file is what enforces it.
+* @LeeroyHannigan

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,104 @@
+# Dependabot configuration.
+#
+# Shared conventions across every ecosystem below:
+#   - cooldown: hold new updates for a few days before opening a PR so we don't
+#     churn on same-day releases. Majors get a long (30-day) window so a human
+#     can vet breaking changes before the PR lands.
+#   - groups: batch low-risk updates into grouped PRs. Major updates are
+#     intentionally left ungrouped so they arrive as individual,
+#     clearly-attributable PRs.
+#   - schedule: poll weekly. The cooldown already delays PRs by days, so daily
+#     polling just adds noise without surfacing updates any sooner.
+#   - versioning-strategy: increase-if-necessary — bump the constraint floor at a
+#     major boundary instead of just widening the upper bound, so CI actually
+#     resolves and tests the new major rather than sitting on the old one.
+version: 2
+updates:
+  # Python package. Dev tooling and minor/patch bumps are batched; major
+  # bumps come individually and wait out the 30-day cooldown for review.
+  - package-ecosystem: 'pip'
+    directory: '/python'
+    schedule:
+      interval: 'weekly'
+    open-pull-requests-limit: 100
+    labels:
+      - 'dependencies'
+      - 'python'
+    commit-message:
+      prefix: 'ci(python)'
+    versioning-strategy: increase-if-necessary
+    cooldown:
+      default-days: 5
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3
+    groups:
+      # Dev tooling in one PR, matched by name because Dependabot does not
+      # classify PEP 621 pyproject dependencies as development vs production,
+      # so dependency-type grouping never matches for pip. Keep these patterns
+      # in sync with the dev extra in python/pyproject.toml — anything missed
+      # here silently falls into production-minor.
+      development-dependencies:
+        applies-to: version-updates
+        patterns:
+          - 'hatch'
+          - 'moto*'
+          - 'mypy'
+          - 'pytest*'
+          - 'ruff'
+      # Everything else: minor + patch bumps in one PR. A dependency joins the
+      # first group it matches, so dev tooling above never lands here.
+      production-minor:
+        applies-to: version-updates
+        patterns:
+          - '*'
+        update-types:
+          - 'minor'
+          - 'patch'
+      # Major production updates aren't matched by any group, so they get
+      # individual PRs — gated by the 30-day semver-major cooldown above.
+  # TypeScript package. Same batching strategy as the Python package.
+  - package-ecosystem: 'npm'
+    directory: '/typescript'
+    schedule:
+      interval: 'weekly'
+    open-pull-requests-limit: 100
+    labels:
+      - 'dependencies'
+      - 'typescript'
+    commit-message:
+      prefix: 'ci(typescript)'
+    versioning-strategy: increase-if-necessary
+    cooldown:
+      default-days: 5
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3
+    groups:
+      # All development dependencies in one PR.
+      development-dependencies:
+        dependency-type: 'development'
+        applies-to: version-updates
+      # Production minor + patch bumps in one PR.
+      production-minor:
+        dependency-type: 'production'
+        applies-to: version-updates
+        update-types:
+          - 'minor'
+          - 'patch'
+      # Major production updates aren't matched by any group, so they get
+      # individual PRs — gated by the 30-day semver-major cooldown above.
+  # GitHub Actions workflow pins. Low volume, so no grouping; the cooldown
+  # still holds majors back for review before the bump PR opens.
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    open-pull-requests-limit: 100
+    commit-message:
+      prefix: ci
+    cooldown:
+      default-days: 5
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,7 +28,7 @@ updates:
       prefix: 'ci(python)'
     versioning-strategy: increase-if-necessary
     cooldown:
-      default-days: 5
+      default-days: 7
       semver-major-days: 30
       semver-minor-days: 7
       semver-patch-days: 3
@@ -70,7 +70,7 @@ updates:
       prefix: 'ci(typescript)'
     versioning-strategy: increase-if-necessary
     cooldown:
-      default-days: 5
+      default-days: 7
       semver-major-days: 30
       semver-minor-days: 7
       semver-patch-days: 3
@@ -98,7 +98,7 @@ updates:
     commit-message:
       prefix: ci
     cooldown:
-      default-days: 5
+      default-days: 7
       semver-major-days: 30
       semver-minor-days: 7
       semver-patch-days: 3

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -88,8 +88,11 @@ updates:
           - 'patch'
       # Major production updates aren't matched by any group, so they get
       # individual PRs — gated by the 30-day semver-major cooldown above.
-  # GitHub Actions workflow pins. Low volume, so no grouping; the cooldown
-  # still holds majors back for review before the bump PR opens.
+  # GitHub Actions workflow pins. Low volume, so no grouping. Actions are
+  # pinned to commit SHAs, and the github-actions ecosystem does not support the
+  # semver-scoped cooldown keys the package ecosystems use above (a SHA carries
+  # no semver, so Dependabot rejects them), leaving default-days as the only
+  # cooldown available here.
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
@@ -99,6 +102,3 @@ updates:
       prefix: ci
     cooldown:
       default-days: 7
-      semver-major-days: 30
-      semver-minor-days: 7
-      semver-patch-days: 3

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -1,0 +1,58 @@
+name: CI - Python
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'python/**'
+      - '.github/workflows/ci-python.yml'
+  push:
+    branches: [ main ]
+    paths:
+      - 'python/**'
+      - '.github/workflows/ci-python.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-python-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    working-directory: python
+
+jobs:
+  check:
+    name: Lint, type-check, unit tests (py${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.10', '3.11', '3.12', '3.13']
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install package with dev extras
+        run: pip install -e '.[dev]'
+
+      - name: Ruff (format check)
+        run: ruff format --check src tests
+
+      - name: Ruff (lint)
+        run: ruff check src tests
+
+      - name: mypy (strict)
+        run: mypy src
+
+      - name: Unit tests (moto, no AWS credentials)
+        # tests/integ is gated behind RUN_INTEG and is intentionally not run here.
+        run: pytest tests -q

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -34,10 +34,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/ci-typescript.yml
+++ b/.github/workflows/ci-typescript.yml
@@ -34,10 +34,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'

--- a/.github/workflows/ci-typescript.yml
+++ b/.github/workflows/ci-typescript.yml
@@ -1,0 +1,53 @@
+name: CI - TypeScript
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'typescript/**'
+      - '.github/workflows/ci-typescript.yml'
+  push:
+    branches: [ main ]
+    paths:
+      - 'typescript/**'
+      - '.github/workflows/ci-typescript.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-typescript-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    working-directory: typescript
+
+jobs:
+  check:
+    name: Type-check, unit tests, build (node ${{ matrix.node-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: ['20', '22']
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+          cache-dependency-path: typescript/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Check (format + lint + type-check + unit tests)
+        run: npm run check
+
+      - name: Build
+        run: npm run build

--- a/.github/workflows/code-scanning.yml
+++ b/.github/workflows/code-scanning.yml
@@ -1,0 +1,104 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Static analysis for both languages in this monorepo.
+#
+# Two layers, deliberately:
+#   1. CodeQL uploads SARIF to GitHub code scanning, so findings land in the
+#      Security tab and notify the repository. That is the alerting mechanism.
+#   2. Semgrep and Bandit fail the build directly, so scanning is enforced even
+#      where code scanning upload is unavailable, and on every pull request from
+#      a fork where SARIF upload is restricted.
+#
+# Findings must be fixed or explicitly suppressed with a justification comment.
+
+name: Code Scanning
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly, so a newly published rule finds existing code without waiting for a commit.
+    - cron: '17 4 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: code-scanning-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  codeql:
+    name: CodeQL (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [python, javascript-typescript]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          queries: security-extended
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: /language:${{ matrix.language }}
+
+  semgrep:
+    name: Semgrep
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install Semgrep
+        run: pip install semgrep
+
+      # --error makes a finding fail the job. Covers Python and TypeScript in one pass.
+      - name: Scan
+        run: semgrep --config p/default --config p/security-audit --error --skip-unknown-extensions .
+
+  bandit:
+    name: Bandit (Python)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install Bandit
+        run: pip install bandit
+
+      # Tests are excluded: assert statements there are the point, not a finding.
+      - name: Scan
+        run: bandit -r python/src -ll
+
+  dependency-review:
+    name: Dependency review
+    # Only meaningful on a pull request, where there is a base to diff against.
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: high

--- a/.github/workflows/code-scanning.yml
+++ b/.github/workflows/code-scanning.yml
@@ -38,21 +38,26 @@ jobs:
     permissions:
       contents: read
       security-events: write
+      # CodeQL reads workflow run metadata to attach results to the run; on a
+      # private repository this is not covered by the default token scopes and
+      # its absence fails the analyze step with "Resource not accessible by
+      # integration" after the SARIF has already been produced.
+      actions: read
     strategy:
       fail-fast: false
       matrix:
         language: [python, javascript-typescript]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@f3712979fa5f215279b101dd0a2e3bdfb4353324 # v3.37.7
         with:
           languages: ${{ matrix.language }}
           queries: security-extended
 
       - name: Analyze
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@f3712979fa5f215279b101dd0a2e3bdfb4353324 # v3.37.7
         with:
           category: /language:${{ matrix.language }}
 
@@ -60,9 +65,9 @@ jobs:
     name: Semgrep
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.12'
 
@@ -77,9 +82,9 @@ jobs:
     name: Bandit (Python)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.12'
 
@@ -98,7 +103,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/dependency-review-action@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
         with:
           fail-on-severity: high

--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -1,0 +1,92 @@
+name: Publish Python to PyPI
+
+# Triggered when a GitHub Release is published with a tag prefixed `python-v`
+# (e.g. `python-v0.1.0`). The published version is whatever is currently in
+# python/pyproject.toml ([project].version) — bump it before tagging, the same
+# way the TypeScript side bumps package.json.
+on:
+  release:
+    types:
+      - published
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    working-directory: python
+
+jobs:
+  check-tag:
+    name: Check tag is python-v*
+    runs-on: ubuntu-latest
+    outputs:
+      should_publish: ${{ steps.check.outputs.should_publish }}
+    steps:
+      - id: check
+        env:
+          TAG_NAME: ${{ github.event.release.tag_name }}
+        run: |
+          if [[ "$TAG_NAME" == python-v* ]]; then
+            echo "should_publish=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_publish=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  build:
+    name: Build distribution
+    needs: check-tag
+    if: needs.check-tag.outputs.should_publish == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Install build tooling
+        run: pip install hatch twine
+
+      - name: Run checks
+        run: |
+          pip install -e '.[dev]'
+          ruff check .
+          mypy src
+          pytest tests -q
+
+      - name: Build package
+        run: hatch build
+
+      - name: Check distribution
+        run: twine check dist/*
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-package-distributions
+          path: python/dist/
+
+  publish:
+    name: Publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    # Create a `pypi` environment in repo settings and register this repo as a
+    # trusted publisher on PyPI (OIDC) — no long-lived API token is stored.
+    environment:
+      name: pypi
+    permissions:
+      id-token: write
+    steps:
+      - name: Download distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0

--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -40,12 +40,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.10'
 
@@ -66,7 +66,7 @@ jobs:
         run: twine check dist/*
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: python-package-distributions
           path: python/dist/
@@ -83,7 +83,7 @@ jobs:
       id-token: write
     steps:
       - name: Download distributions
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: python-package-distributions
           path: dist/

--- a/.github/workflows/publish-typescript.yml
+++ b/.github/workflows/publish-typescript.yml
@@ -1,0 +1,72 @@
+name: Publish TypeScript to npm
+
+# Triggered when a GitHub Release is published with a tag prefixed `typescript-v`
+# (e.g. `typescript-v0.1.0`). The published version is whatever is currently in
+# typescript/package.json — bump it before tagging.
+on:
+  release:
+    types:
+      - published
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    working-directory: typescript
+
+jobs:
+  check-tag:
+    name: Check tag is typescript-v*
+    runs-on: ubuntu-latest
+    outputs:
+      should_publish: ${{ steps.check.outputs.should_publish }}
+    steps:
+      - id: check
+        env:
+          TAG_NAME: ${{ github.event.release.tag_name }}
+        run: |
+          if [[ "$TAG_NAME" == typescript-v* ]]; then
+            echo "should_publish=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_publish=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  publish:
+    name: Publish to npm
+    needs: check-tag
+    if: needs.check-tag.outputs.should_publish == 'true'
+    runs-on: ubuntu-latest
+    # Create an `npm` environment in repo settings to gate publishes behind
+    # required reviewers, and scope the NPM_TOKEN secret to it.
+    environment:
+      name: npm
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'npm'
+          cache-dependency-path: typescript/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run checks
+        run: npm run check
+
+      - name: Build
+        run: npm run build
+
+      - name: Publish
+        run: npm publish --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish-typescript.yml
+++ b/.github/workflows/publish-typescript.yml
@@ -47,10 +47,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Ignore the `build/` directory in the package root.
+/build

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # strands-dynamodb-storage
 
-A community **Amazon DynamoDB `Storage` backend** for the [Strands Agents](https://github.com/strands-agents/harness-sdk) SDK,
+An **Amazon DynamoDB `Storage` backend** for the [Strands Agents](https://github.com/strands-agents/harness-sdk) SDK,
 provided for **both TypeScript and Python** from one monorepo (following the Strands `extension-template` `typescript/` + `python/` layout).
 
 It implements the SDK's unified byte `Storage` interface — `write` / `read` / `delete` / `list` / `namespace` — so a single

--- a/README.md
+++ b/README.md
@@ -1,17 +1,38 @@
-## My Project
+# strands-dynamodb-storage
 
-TODO: Fill this README out!
+A community **Amazon DynamoDB `Storage` backend** for the [Strands Agents](https://github.com/strands-agents/harness-sdk) SDK,
+provided for **both TypeScript and Python** from one monorepo (following the Strands `extension-template` `typescript/` + `python/` layout).
 
-Be sure to:
+It implements the SDK's unified byte `Storage` interface — `write` / `read` / `delete` / `list` / `namespace` — so a single
+DynamoDB-backed instance can be passed to **Session Manager, Memory Manager, the context offloader, transcripts**, and any
+other subsystem that persists bytes. No per-subsystem code.
 
-* Change the title in this README
-* Edit your repository description on GitHub
+## Layout
 
-## Security
+| Path | Package | Publishes to | Status |
+|------|---------|--------------|--------|
+| `typescript/` | `strands-dynamodb-storage` | npm | **complete** — unit + real-DynamoDB/S3 integ + live vector `search()` |
+| `python/` | `strands-dynamodb-storage` | PyPI | **complete** — parity port; unit (moto) + real-DynamoDB/S3 integ |
 
-See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more information.
+## Capabilities (both languages)
 
-## License
+- **Single-table design** — the `/`-separated key maps to a partition key (leading scope) + sort key (remainder); point ops
+  are single-item `PutItem`/`GetItem`/`DeleteItem`.
+- **`list(prefix)`** resolves to a native partition `Query` with `begins_with`; a structured **`DynamoDBListQuery`** (pk/sk)
+  is the intended DynamoDB extension point of the generic `Storage` interface — no GSI required.
+- **S3 offload** for values above the 400&nbsp;KB item limit (opt-in `s3Bucket`); a small pointer item stays in DynamoDB.
+- **Optional gzip compression** — applied before the offload size check, so compressible values stay inline (lower cost);
+  per-item marker so reads are correct regardless of the setting.
+- **Optional TTL** — stamps a DynamoDB-native epoch-seconds attribute; `read`/`list` also filter already-expired items.
+- **Optional `search()`** — nearest-neighbour vector search over DynamoDB's native vector index, feature-detected
+  (`if (storage.search)`), with a client-side-KNN fallback for backends that don't implement it.
 
-This project is licensed under the Apache-2.0 License.
+The AWS SDK clients are lazy-loaded / declared as peer (optional) dependencies, so consumers that never construct a
+`DynamoDBStorage` are not forced to install them.
 
+## Releases
+
+Both packages are published from this repository under the name `strands-dynamodb-storage`: the npm package from
+`typescript/` and the PyPI package from `python/`. Each is cut by publishing a GitHub Release whose tag carries the
+language prefix (`typescript-v0.1.0`, `python-v0.1.0`); the workflow verifies the prefix, so the two languages version
+independently.

--- a/python/.gitignore
+++ b/python/.gitignore
@@ -1,0 +1,8 @@
+.venv/
+__pycache__/
+*.egg-info/
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+dist/
+build/

--- a/python/LICENSE
+++ b/python/LICENSE
@@ -1,0 +1,175 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.

--- a/python/NOTICE
+++ b/python/NOTICE
@@ -1,0 +1,1 @@
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.

--- a/python/README.md
+++ b/python/README.md
@@ -1,0 +1,52 @@
+# strands-dynamodb-storage (Python)
+
+Python implementation of the Amazon DynamoDB `Storage` backend for the Strands Agents SDK — at
+parity with `../typescript/`. Implements the SDK's `strands.storage.Storage` protocol
+(`write`/`read`/`delete`/`list`, plus `namespace`) so one DynamoDB-backed instance serves Session
+Manager, Memory Manager, and any subsystem that persists bytes.
+
+## Install
+
+```bash
+pip install strands-dynamodb-storage
+```
+
+## Usage
+
+```python
+from strands import Agent
+from strands.session import SessionManager
+from strands_dynamodb_storage import DynamoDBStorage
+
+storage = DynamoDBStorage("agent-data", region_name="us-east-1")
+agent = Agent(session_manager=SessionManager(storage=storage))
+```
+
+Direct byte usage (async):
+
+```python
+store = DynamoDBStorage("agent-data", region_name="us-east-1")
+await store.write("sessions/s1/snapshot.json", b'{"turn": 1}')
+data = await store.read("sessions/s1/snapshot.json")           # bytes | None
+keys = await store.list("sessions/s1/")                         # native Query
+scoped = await store.list(DynamoDBListQuery(pk="sessions/s1", sk_prefix="scopes/"))
+await store.delete("sessions/s1/snapshot.json")
+```
+
+## Features (parity with the TypeScript package)
+
+- Single-table design (`pk`/`sk`), with a structured `DynamoDBListQuery` extension point.
+- Optional Amazon S3 offload for values above the item-size limit (`s3_bucket=...`).
+- Optional gzip `compression="gzip"` (applied before the offload check).
+- Optional per-item TTL (`ttl_seconds=...`) with read/list expiry filtering.
+- Native vector `search()` via Amazon DynamoDB vector indexes (`SearchVectors`,
+  requires boto3 >= 1.43.64); a `vector_search` adapter can override the call.
+
+## Development
+
+```bash
+python -m venv .venv && .venv/bin/pip install -e ".[dev]"
+.venv/bin/python -m pytest -q            # unit tests (moto, offline)
+.venv/bin/ruff check src tests && .venv/bin/mypy src
+RUN_INTEG=1 AWS_REGION=us-east-1 .venv/bin/python -m pytest tests/integ -q   # real DynamoDB + S3
+```

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,0 +1,71 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "strands-dynamodb-storage"
+version = "0.1.0"
+description = "Amazon DynamoDB storage backend for the Strands Agents SDK"
+readme = "README.md"
+requires-python = ">=3.10"
+license = "Apache-2.0"
+authors = [{ name = "Amazon Web Services" }]
+keywords = ["strands", "strands-agents", "dynamodb", "storage", "agent", "memory", "aws"]
+dependencies = [
+    "strands-agents",
+    "boto3>=1.43.64",
+]
+
+[project.urls]
+Homepage = "https://github.com/aws/strands-dynamodb-storage"
+Repository = "https://github.com/aws/strands-dynamodb-storage"
+Issues = "https://github.com/aws/strands-dynamodb-storage/issues"
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8",
+    "pytest-asyncio>=0.23",
+    "moto[dynamodb,s3]>=5",
+    "ruff",
+    "mypy",
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/strands_dynamodb_storage"]
+
+[tool.hatch.envs.default]
+dependencies = [
+    "pytest>=8",
+    "pytest-asyncio>=0.23",
+    "moto[dynamodb,s3]>=5",
+    "ruff",
+    "mypy",
+]
+
+[tool.hatch.envs.default.scripts]
+test = "pytest {args}"
+lint = "ruff check src tests"
+format = "ruff format src tests"
+format-check = "ruff format --check src tests"
+typecheck = "mypy src"
+prepare = ["format", "lint", "typecheck", "test"]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]
+
+[tool.ruff]
+line-length = 120
+include = ["src/**/*.py", "tests/**/*.py"]
+
+[tool.ruff.lint]
+# Matches strands-agents/extension-template: pycodestyle, pyflakes, isort, bugbear.
+select = ["E", "F", "I", "B"]
+
+[tool.mypy]
+python_version = "3.10"
+strict = true
+
+[[tool.mypy.overrides]]
+module = ["boto3", "boto3.*", "botocore", "botocore.*"]
+ignore_missing_imports = true

--- a/python/src/strands_dynamodb_storage/__init__.py
+++ b/python/src/strands_dynamodb_storage/__init__.py
@@ -1,0 +1,25 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Amazon DynamoDB storage backend for the Strands Agents SDK.
+
+Implements the SDK's unified byte ``Storage`` interface, so one DynamoDB-backed
+instance persists any subsystem's data (Session Manager, Memory Manager, offloader,
+transcripts) — with optional S3 offload, gzip compression, TTL, and native vector search.
+"""
+
+from .dynamodb_storage import (
+    DynamoDBListQuery,
+    DynamoDBStorage,
+    SearchQuery,
+    SearchResult,
+    VectorSearchAdapter,
+)
+
+__all__ = [
+    "DynamoDBStorage",
+    "DynamoDBListQuery",
+    "SearchQuery",
+    "SearchResult",
+    "VectorSearchAdapter",
+]

--- a/python/src/strands_dynamodb_storage/dynamodb_storage.py
+++ b/python/src/strands_dynamodb_storage/dynamodb_storage.py
@@ -1,0 +1,678 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Amazon DynamoDB ``Storage`` backend for the Strands Agents SDK."""
+
+from __future__ import annotations
+
+import asyncio
+import builtins
+import gzip
+import math
+import time
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Any, Optional, Union
+
+from strands.types.exceptions import StorageError
+
+from .keys import normalize_key, normalize_prefix
+
+# Single-table attribute names.
+_PK = "pk"
+_SK = "sk"
+_KEY_ATTR = "k"
+_DATA_ATTR = "data"
+_S3_ATTR = "s3"
+_META_ATTR = "meta"
+_Z_ATTR = "z"
+
+# Leave margin below DynamoDB's 400 KB item limit for keys/metadata.
+_OFFLOAD_THRESHOLD_BYTES = 380_000
+# Sentinel sort key for single-segment keys, so point ops round-trip.
+_SENTINEL_SK = "\u0000"
+# Service maximum for SearchVectors TopK ("must be between 1 and 100 inclusive").
+_MAX_TOP_K = 100
+# Over-fetch factor when a client-side metadata filter is applied, so filtering
+# doesn't silently drop results below the requested top_k.
+_FILTER_OVERFETCH = 10
+
+_MetaValue = Union[str, int, float, bool]
+
+# Optional override for the native vector search call (DynamoDB SearchVectors).
+# Receives a params dict and returns match dicts: {"key", "score", "metadata"?}.
+VectorSearchAdapter = Callable[[dict[str, Any]], Awaitable[builtins.list[dict[str, Any]]]]
+
+
+@dataclass
+class DynamoDBListQuery:
+    """Structured list query naming the partition directly.
+
+    The ``Storage`` ``list`` argument is generic so backends like DynamoDB can accept
+    a richer query than a string prefix. A ``DynamoDBListQuery`` names the partition
+    (``pk``), so listing is a native ``Query`` against one partition. SDK-internal
+    callers still pass a plain string prefix.
+    """
+
+    pk: str
+    sk_prefix: Optional[str] = None
+    sk_between: Optional[tuple[str, str]] = None
+    limit: Optional[int] = None
+    start_after: Optional[str] = None
+
+
+@dataclass
+class SearchQuery:
+    """Vector similarity query for the optional native vector index."""
+
+    vector: builtins.list[float]
+    top_k: int
+    pk: Optional[str] = None
+    filter: Optional[dict[str, _MetaValue]] = None
+    include_values: bool = False
+
+
+@dataclass
+class SearchResult:
+    """A single nearest-neighbour match."""
+
+    key: str
+    score: float
+    data: Optional[bytes] = None
+    metadata: Optional[dict[str, Any]] = None
+
+
+def _clean_prefix(prefix: str) -> str:
+    """Collapse/strip a prefix and add a single trailing slash (empty stays empty)."""
+    joined = "/".join(seg for seg in prefix.split("/") if seg)
+    return f"{joined}/" if joined else ""
+
+
+def _unmarshal_meta(attr: Optional[dict[str, Any]]) -> Optional[dict[str, Any]]:
+    """Inverse of :func:`_marshal_meta` for the flat metadata map."""
+    if attr is None:
+        return None
+    out: dict[str, Any] = {}
+    for key, value in attr.get("M", {}).items():
+        if "BOOL" in value:
+            out[key] = value["BOOL"]
+        elif "N" in value:
+            raw = value["N"]
+            number = float(raw)
+            out[key] = int(number) if number.is_integer() and "." not in raw and "e" not in raw.lower() else number
+        else:
+            out[key] = value.get("S")
+    return out
+
+
+def _marshal_meta(meta: dict[str, _MetaValue]) -> dict[str, Any]:
+    """Marshal a flat metadata map to a DynamoDB ``M`` AttributeValue."""
+    out: dict[str, Any] = {}
+    for key, value in meta.items():
+        # bool is a subclass of int — check it first.
+        if isinstance(value, bool):
+            out[key] = {"BOOL": value}
+        elif isinstance(value, (int, float)):
+            out[key] = {"N": str(value)}
+        else:
+            out[key] = {"S": str(value)}
+    return {"M": out}
+
+
+class DynamoDBStorage:
+    """DynamoDB ``Storage`` backend (single-table design).
+
+    Each key is one item: the ``/``-separated key is split into a partition key
+    (leading scope) and a sort key (remainder), with the raw bytes in a binary
+    ``data`` attribute. Point operations are single-item Put/Get/Delete; listing is a
+    native ``Query`` — a string prefix resolves to a partition plus ``begins_with``,
+    while a :class:`DynamoDBListQuery` names the partition directly.
+
+    Values above the 400 KB item limit are offloaded to S3 when ``s3_bucket`` is set;
+    a small pointer item stays in DynamoDB. Optional transparent gzip compression,
+    optional DynamoDB-native TTL (with read/list filtering of expired items), and an
+    optional native vector ``search`` complete the feature set. boto3 is imported
+    lazily, so applications that never construct this class don't pay the import cost.
+
+    Example:
+        ```python
+        from strands import Agent
+        from strands.session import SessionManager
+        from strands_dynamodb_storage import DynamoDBStorage
+
+        storage = DynamoDBStorage("agent-data", region_name="us-east-1")
+        agent = Agent(session_manager=SessionManager(storage=storage))
+        ```
+    """
+
+    def __init__(
+        self,
+        table_name: str,
+        *,
+        region_name: Optional[str] = None,
+        client: Any = None,
+        prefix: str = "",
+        s3_bucket: Optional[str] = None,
+        s3_prefix: str = "",
+        s3_client: Any = None,
+        compression: str = "none",
+        ttl_seconds: Optional[int] = None,
+        ttl_attribute: str = "expireAt",
+        index_name: str = "vector_index",
+        vector_attribute: str = "vector",
+        vector_search: Optional[VectorSearchAdapter] = None,
+        boto_session: Any = None,
+        boto_client_config: Any = None,
+    ) -> None:
+        """Initialize the backend.
+
+        Args:
+            table_name: Target table (partition key ``pk`` string, sort key ``sk`` string).
+            region_name: AWS region override. Cannot be combined with ``client``.
+            client: Pre-configured low-level DynamoDB client.
+            prefix: Key prefix prepended to every key (a namespace within the table).
+            s3_bucket: Bucket for offloading values above the item-size limit.
+            s3_prefix: Key prefix for offloaded S3 objects.
+            s3_client: Pre-configured S3 client. Ignored unless ``s3_bucket`` is set.
+            compression: ``"gzip"`` for transparent compression, or ``"none"``.
+            ttl_seconds: Default TTL. Setting it opts in to TTL (stamp + read/list filter).
+            ttl_attribute: Item attribute holding the epoch-seconds TTL.
+            index_name: Vector index name (for ``search``).
+            vector_attribute: Item attribute holding the embedding vector.
+            vector_search: Adapter performing the native vector search.
+            boto_session: Pre-configured boto3 session. Cannot be combined with region_name.
+            boto_client_config: Botocore Config for the created clients.
+
+        Raises:
+            StorageError: If both ``client`` and ``region_name`` are provided.
+        """
+        if client is not None and region_name is not None:
+            raise StorageError("Cannot specify both client and region_name; configure the region on the client instead")
+
+        self._table_name = table_name
+        self._region_name = region_name
+        self._client = client
+        self._prefix = _clean_prefix(prefix)
+        self._s3_bucket = s3_bucket
+        self._s3_prefix = _clean_prefix(s3_prefix)
+        self._s3_client = s3_client
+        self._compress = compression == "gzip"
+        self._ttl_seconds = ttl_seconds
+        self._ttl_enabled = ttl_seconds is not None
+        self._ttl_attribute = ttl_attribute
+        self._index_name = index_name
+        self._vector_attribute = vector_attribute
+        self._vector_search = vector_search
+        self._boto_session = boto_session
+        self._boto_client_config = boto_client_config
+
+    async def write(
+        self,
+        key: str,
+        data: bytes,
+        *,
+        vector: Optional[builtins.list[float]] = None,
+        metadata: Optional[dict[str, _MetaValue]] = None,
+        ttl_seconds: Optional[int] = None,
+    ) -> None:
+        """Store ``data`` under ``key``, overwriting any existing value.
+
+        Values above the item-size limit offload to S3 when ``s3_bucket`` is set.
+        An optional ``vector`` (kept inline for the native index) and ``metadata``
+        enable :meth:`search`.
+
+        Raises:
+            StorageError: If the key is invalid, the value is oversized with no S3
+                bucket configured, or the write fails.
+        """
+        normalized = normalize_key(key)
+        full = f"{self._prefix}{normalized}"
+        pk, sk = self._split(full)
+
+        extra: dict[str, Any] = {}
+        # The embedding stays inline even when the payload offloads, because the
+        # native vector index can only index an on-item attribute.
+        if vector is not None:
+            extra[self._vector_attribute] = {"L": [{"N": str(component)} for component in vector]}
+        if metadata is not None:
+            extra[_META_ATTR] = _marshal_meta(metadata)
+        effective_ttl = ttl_seconds if ttl_seconds is not None else self._ttl_seconds
+        if self._ttl_enabled and effective_ttl is not None:
+            extra[self._ttl_attribute] = {"N": str(int(time.time()) + effective_ttl)}
+
+        payload = data
+        compressed = False
+        if self._compress:
+            gz = gzip.compress(data)
+            if len(gz) < len(data):
+                payload = gz
+                compressed = True
+        if compressed:
+            extra[_Z_ATTR] = {"BOOL": True}
+
+        try:
+            if len(payload) > _OFFLOAD_THRESHOLD_BYTES:
+                if not self._s3_bucket:
+                    raise StorageError(
+                        f"Value for '{normalized}' is {len(payload)} bytes, above the "
+                        f"{_OFFLOAD_THRESHOLD_BYTES}-byte limit; configure s3_bucket to offload large values"
+                    )
+                await self._s3_put(full, payload)
+                item = {_PK: {"S": pk}, _SK: {"S": sk}, _KEY_ATTR: {"S": full}, _S3_ATTR: {"BOOL": True}, **extra}
+            else:
+                item = {_PK: {"S": pk}, _SK: {"S": sk}, _KEY_ATTR: {"S": full}, _DATA_ATTR: {"B": payload}, **extra}
+            await self._put(item)
+        except StorageError:
+            raise
+        except Exception as error:
+            raise StorageError(f"Failed to write '{normalized}' to DynamoDB table '{self._table_name}'") from error
+
+    async def read(self, key: str) -> Optional[bytes]:
+        """Retrieve the bytes stored under ``key``, or ``None`` if absent.
+
+        Raises:
+            StorageError: If the key is invalid or the read fails.
+        """
+        normalized = normalize_key(key)
+        full = f"{self._prefix}{normalized}"
+        pk, sk = self._split(full)
+        try:
+            client = self._get_client()
+            response = await asyncio.to_thread(
+                client.get_item, TableName=self._table_name, Key={_PK: {"S": pk}, _SK: {"S": sk}}
+            )
+            item = response.get("Item")
+            if not item:
+                return None
+            # Hide items whose TTL has passed but DynamoDB has not yet reaped (only
+            # when TTL is opted in). Runs before any S3 fetch.
+            if self._ttl_enabled and self._is_expired(item):
+                return None
+            compressed = item.get(_Z_ATTR, {}).get("BOOL") is True
+            if item.get(_S3_ATTR, {}).get("BOOL"):
+                raw = await self._s3_get(full)
+            else:
+                raw = item.get(_DATA_ATTR, {}).get("B")
+                raw = bytes(raw) if raw is not None else None
+            if raw is None:
+                return None
+            return gzip.decompress(raw) if compressed else raw
+        except StorageError:
+            raise
+        except Exception as error:
+            raise StorageError(f"Failed to read '{normalized}' from DynamoDB table '{self._table_name}'") from error
+
+    async def delete(self, key: str) -> None:
+        """Delete the value under ``key`` (and any offloaded S3 object). No-op if absent.
+
+        Raises:
+            StorageError: If the key is invalid or the delete fails.
+        """
+        normalized = normalize_key(key)
+        full = f"{self._prefix}{normalized}"
+        pk, sk = self._split(full)
+        try:
+            client = self._get_client()
+            response = await asyncio.to_thread(
+                client.delete_item,
+                TableName=self._table_name,
+                Key={_PK: {"S": pk}, _SK: {"S": sk}},
+                ReturnValues="ALL_OLD",
+            )
+            if response.get("Attributes", {}).get(_S3_ATTR, {}).get("BOOL"):
+                await self._s3_delete(full)
+        except StorageError:
+            raise
+        except Exception as error:
+            raise StorageError(f"Failed to delete '{normalized}' from DynamoDB table '{self._table_name}'") from error
+
+    async def list(self, query: Union[str, DynamoDBListQuery]) -> builtins.list[str]:
+        """List keys, sorted ascending.
+
+        Accepts a **string prefix** (resolved to a partition plus ``begins_with``; must
+        include at least the scope and identifier) or a :class:`DynamoDBListQuery`
+        naming the partition directly.
+
+        Raises:
+            StorageError: If the query is invalid or the list fails.
+        """
+        try:
+            if isinstance(query, str):
+                return await self._list_by_prefix(query)
+            return await self._list_by_query(query)
+        except StorageError:
+            raise
+        except Exception as error:
+            label = f"'{query}'" if isinstance(query, str) else f"pk='{query.pk}'"
+            raise StorageError(f"Failed to list DynamoDB table '{self._table_name}' under {label}") from error
+
+    def namespace(self, prefix: str) -> DynamoDBStorage:
+        """Return a prefixed view sharing this client/config.
+
+        Returns a real :class:`DynamoDBStorage` (not the SDK's generic string-only
+        namespace view), so structured :class:`DynamoDBListQuery` listing and
+        :meth:`search` survive namespacing. Nested calls compose.
+        """
+        sub = normalize_prefix(prefix)
+        kwargs: dict[str, Any] = {
+            "prefix": f"{self._prefix}{sub}",
+            "s3_prefix": self._s3_prefix,
+            "index_name": self._index_name,
+            "vector_attribute": self._vector_attribute,
+        }
+        if self._client is not None:
+            kwargs["client"] = self._client
+        elif self._region_name is not None:
+            kwargs["region_name"] = self._region_name
+        if self._s3_bucket is not None:
+            kwargs["s3_bucket"] = self._s3_bucket
+        if self._s3_client is not None:
+            kwargs["s3_client"] = self._s3_client
+        if self._compress:
+            kwargs["compression"] = "gzip"
+        if self._ttl_seconds is not None:
+            kwargs["ttl_seconds"] = self._ttl_seconds
+        kwargs["ttl_attribute"] = self._ttl_attribute
+        if self._vector_search is not None:
+            kwargs["vector_search"] = self._vector_search
+        if self._boto_session is not None:
+            kwargs["boto_session"] = self._boto_session
+        if self._boto_client_config is not None:
+            kwargs["boto_client_config"] = self._boto_client_config
+        return DynamoDBStorage(self._table_name, **kwargs)
+
+    async def search(self, query: SearchQuery) -> builtins.list[SearchResult]:
+        """Nearest-neighbour vector search over items written with a ``vector``.
+
+        Optional part of the ``Storage`` contract — consumers feature-detect
+        (``hasattr(storage, "search")``) and fall back to client-side KNN when absent.
+        Calls DynamoDB ``SearchVectors`` natively (requires boto3 >= 1.43.64); a
+        ``vector_search`` adapter, when configured, overrides the native call.
+
+        The score is the raw ``Score`` from the vector index and its direction
+        depends on the index's distance function: for COSINE and EUCLIDEAN lower
+        is closer; for DOT_PRODUCT higher is more similar. Results are returned
+        in the service's most-similar-first order. Like a global secondary
+        index, the vector index is eventually consistent.
+
+        Raises:
+            StorageError: If the search fails or ``top_k`` is out of range.
+        """
+        if query.pk is not None:
+            self._assert_pk_in_scope(query.pk)
+        try:
+            if self._vector_search is not None:
+                params: dict[str, Any] = {
+                    "table_name": self._table_name,
+                    "index_name": self._index_name,
+                    "vector_attribute": self._vector_attribute,
+                    "vector": query.vector,
+                    "top_k": query.top_k,
+                }
+                if query.pk is not None:
+                    params["pk"] = query.pk
+                if query.filter is not None:
+                    params["filter"] = query.filter
+                matches = await self._vector_search(params)
+            else:
+                matches = await self._native_vector_search(query)
+            results: builtins.list[SearchResult] = []
+            for match in matches:
+                # Defence in depth: pk is optional, so the index may return matches from
+                # outside this namespace. Drop them rather than de-prefixing blindly —
+                # a foreign key would otherwise be handed back looking like one of ours.
+                key = self._strip_prefix(match["key"])
+                if key is None:
+                    continue
+                data = None
+                if query.include_values:
+                    data = await self.read(key)
+                results.append(SearchResult(key=key, score=match["score"], data=data, metadata=match.get("metadata")))
+            return results
+        except StorageError:
+            raise
+        except Exception as error:
+            raise StorageError(f"Failed to search DynamoDB table '{self._table_name}'") from error
+
+    async def _native_vector_search(self, query: SearchQuery) -> builtins.list[dict[str, Any]]:
+        """Issue DynamoDB ``SearchVectors`` directly (GA path, no adapter).
+
+        Scoping and filtering:
+
+        * ``query.pk`` pins ``SearchConditionExpression`` to one partition
+          (already namespace-validated by the caller).
+        * ``query.filter`` is applied client-side after the search, with the
+          request over-fetching (capped at the service TopK limit of 100) so
+          filtering doesn't silently drop results below ``top_k``. A filtered
+          search can still return fewer than ``top_k`` matches once the cap
+          truncates the over-fetch.
+        """
+        if query.top_k < 1 or query.top_k > _MAX_TOP_K:
+            raise StorageError(
+                f"top_k must be between 1 and {_MAX_TOP_K} (SearchVectors TopK limit); got {query.top_k}"
+            )
+        if not all(math.isfinite(v) for v in query.vector):
+            raise StorageError("Query vector contains non-finite values (nan/inf); the DynamoDB N type rejects them.")
+        top_k = query.top_k
+        if query.filter is not None:
+            top_k = min(query.top_k * _FILTER_OVERFETCH, _MAX_TOP_K)
+
+        request: dict[str, Any] = {
+            "TableName": self._table_name,
+            "IndexName": self._index_name,
+            "SearchVector": [{"N": str(v)} for v in query.vector],
+            "TopK": top_k,
+        }
+        if query.pk is not None:
+            request["SearchConditionExpression"] = "#pk = :pk"
+            request["ExpressionAttributeNames"] = {"#pk": _PK}
+            request["ExpressionAttributeValues"] = {":pk": {"S": query.pk}}
+
+        client = self._get_client()
+        response = await asyncio.to_thread(client.search_vectors, **request)
+
+        matches: builtins.list[dict[str, Any]] = []
+        for result in response.get("SearchResults", []):
+            item = result["Item"]
+            pk = item[_PK]["S"]
+            sk = item.get(_SK, {}).get("S", "")
+            full_key = pk if sk in ("", _SENTINEL_SK) else f"{pk}/{sk}"
+            metadata = _unmarshal_meta(item.get(_META_ATTR))
+            if query.filter is not None and not self._matches_search_filter(metadata, query.filter):
+                continue
+            match: dict[str, Any] = {"key": full_key, "score": float(result["Score"])}
+            if metadata is not None:
+                match["metadata"] = metadata
+            matches.append(match)
+            if len(matches) >= query.top_k:
+                break
+        return matches
+
+    @staticmethod
+    def _matches_search_filter(metadata: Optional[dict[str, Any]], filter_dict: dict[str, _MetaValue]) -> bool:
+        """Exact-equality match of every filter entry against item metadata."""
+        if metadata is None:
+            return False
+        return all(metadata.get(k) == v for k, v in filter_dict.items())
+
+    # ------------------------------------------------------------------ internals
+
+    def _split(self, full_key: str) -> tuple[str, str]:
+        """Split a full key into (partition key, sort key)."""
+        segments = [seg for seg in full_key.split("/") if seg]
+        if len(segments) <= 1:
+            return (segments[0] if segments else full_key), _SENTINEL_SK
+        return "/".join(segments[:2]), ("/".join(segments[2:]) or _SENTINEL_SK)
+
+    def _is_expired(self, item: dict[str, Any]) -> bool:
+        """True when the item's TTL attribute holds a past epoch-seconds value."""
+        raw = item.get(self._ttl_attribute, {}).get("N")
+        return raw is not None and int(raw) <= int(time.time())
+
+    def _assert_pk_in_scope(self, pk: str) -> None:
+        """Reject a caller-supplied partition key that falls outside this namespace.
+
+        ``write``/``read``/``delete`` and the string-prefix ``list`` all derive the
+        physical partition from ``prefix + key``, so the namespace is enforced by
+        construction. A :class:`DynamoDBListQuery` and :class:`SearchQuery` name the
+        partition directly, so the same boundary is enforced here instead. The
+        partition is rejected rather than silently rewritten: a caller asking for
+        another namespace's partition has a bug or is probing, and neither should be
+        answered with quietly different data.
+
+        A partition at or below the namespace is in scope. So is an ancestor partition:
+        because the physical partition is only the first two key segments, a deeply
+        namespaced view legitimately lives inside a shallower partition, and any rows
+        outside the namespace are dropped by :meth:`_strip_prefix`. A partition on a
+        different branch (another tenant) is rejected.
+        """
+        if not self._prefix:
+            return
+        candidate = pk if pk.endswith("/") else f"{pk}/"
+        if pk.startswith(self._prefix) or self._prefix.startswith(candidate):
+            return
+        raise StorageError(
+            f"Partition key '{pk}' is outside this storage namespace '{self._prefix}'. "
+            f"Prefix the partition key with '{self._prefix}' (for example "
+            f"'{self._prefix}sessions') or use the storage instance that owns it."
+        )
+
+    def _strip_prefix(self, stored: str) -> Optional[str]:
+        """Strip the namespace prefix from a stored key, or ``None`` if out of scope.
+
+        Guards the de-prefix: slicing blindly would turn another namespace's key into
+        something that looks like one of ours.
+        """
+        if not self._prefix:
+            return stored
+        if not stored.startswith(self._prefix):
+            return None
+        return stored[len(self._prefix) :]
+
+    async def _list_by_prefix(self, prefix: str) -> builtins.list[str]:
+        normalized = normalize_prefix(prefix)
+        full = f"{self._prefix}{normalized}"
+        segments = [seg for seg in full.split("/") if seg]
+        if len(segments) < 2:
+            raise StorageError(
+                f"DynamoDB list prefix '{prefix}' is too broad; include at least the scope and identifier "
+                f"(e.g. 'sessions/<id>/'). Cross-partition listing requires a DynamoDBListQuery."
+            )
+        pk = "/".join(segments[:2])
+        sk_prefix = "/".join(segments[2:])
+        return await self._list_by_query(DynamoDBListQuery(pk=pk, sk_prefix=sk_prefix or None))
+
+    async def _list_by_query(self, query: DynamoDBListQuery) -> builtins.list[str]:
+        if query.sk_prefix is not None and query.sk_between is not None:
+            raise StorageError("DynamoDBListQuery accepts sk_prefix or sk_between, not both")
+        self._assert_pk_in_scope(query.pk)
+
+        names: dict[str, str] = {"#pk": _PK, "#k": _KEY_ATTR}
+        values: dict[str, Any] = {":pk": {"S": query.pk}}
+        condition = "#pk = :pk"
+        if query.sk_prefix is not None:
+            names["#sk"] = _SK
+            values[":sk"] = {"S": query.sk_prefix}
+            condition += " AND begins_with(#sk, :sk)"
+        elif query.sk_between is not None:
+            names["#sk"] = _SK
+            values[":from"] = {"S": query.sk_between[0]}
+            values[":to"] = {"S": query.sk_between[1]}
+            condition += " AND #sk BETWEEN :from AND :to"
+
+        # Hide expired items — only when TTL is opted in. attribute_not_exists keeps
+        # rows written before TTL was enabled from being dropped.
+        filter_expression: Optional[str] = None
+        if self._ttl_enabled:
+            names["#ttl"] = self._ttl_attribute
+            values[":now"] = {"N": str(int(time.time()))}
+            filter_expression = "(attribute_not_exists(#ttl) OR #ttl > :now)"
+
+        client = self._get_client()
+        keys: builtins.list[str] = []
+        exclusive_start_key: Optional[dict[str, Any]] = None
+        while True:
+            kwargs: dict[str, Any] = {
+                "TableName": self._table_name,
+                "KeyConditionExpression": condition,
+                "ExpressionAttributeNames": names,
+                "ExpressionAttributeValues": values,
+                "ProjectionExpression": "#k",
+            }
+            if filter_expression:
+                kwargs["FilterExpression"] = filter_expression
+            # DynamoDB's Limit caps items *evaluated* before the FilterExpression, and our
+            # start_after skip is applied client-side — so passing Limit while either is
+            # active can under-return. Only push Limit down when neither is in play;
+            # otherwise the client-side count below is authoritative.
+            if query.limit and not filter_expression and query.start_after is None:
+                kwargs["Limit"] = query.limit
+            if exclusive_start_key:
+                kwargs["ExclusiveStartKey"] = exclusive_start_key
+
+            response = await asyncio.to_thread(client.query, **kwargs)
+            for item in response.get("Items", []):
+                stored = item.get(_KEY_ATTR, {}).get("S")
+                if stored is None:
+                    continue
+                key = self._strip_prefix(stored)
+                if key is None:
+                    continue
+                # Apply start_after during collection (before the limit check) so a limit
+                # is filled with post-cursor keys rather than truncated after the fact.
+                if query.start_after is not None and key <= query.start_after:
+                    continue
+                keys.append(key)
+                if query.limit and len(keys) >= query.limit:
+                    return sorted(keys)
+            exclusive_start_key = response.get("LastEvaluatedKey")
+            if not exclusive_start_key:
+                break
+        return sorted(keys)
+
+    async def _put(self, item: dict[str, Any]) -> None:
+        client = self._get_client()
+        await asyncio.to_thread(client.put_item, TableName=self._table_name, Item=item)
+
+    def _s3_key(self, full_key: str) -> str:
+        return f"{self._s3_prefix}{full_key}"
+
+    async def _s3_put(self, full_key: str, data: bytes) -> None:
+        client = self._get_s3_client()
+        await asyncio.to_thread(client.put_object, Bucket=self._s3_bucket, Key=self._s3_key(full_key), Body=data)
+
+    async def _s3_get(self, full_key: str) -> Optional[bytes]:
+        client = self._get_s3_client()
+        response = await asyncio.to_thread(client.get_object, Bucket=self._s3_bucket, Key=self._s3_key(full_key))
+        return await asyncio.to_thread(response["Body"].read)
+
+    async def _s3_delete(self, full_key: str) -> None:
+        client = self._get_s3_client()
+        await asyncio.to_thread(client.delete_object, Bucket=self._s3_bucket, Key=self._s3_key(full_key))
+
+    def _make_config(self) -> Any:
+        from botocore.config import Config
+
+        config = self._boto_client_config
+        if config is None:
+            return Config(user_agent_extra="strands-dynamodb-storage")
+        if not getattr(config, "user_agent_extra", None):
+            return config.merge(Config(user_agent_extra="strands-dynamodb-storage"))
+        return config
+
+    def _session(self) -> Any:
+        import boto3
+
+        return self._boto_session if self._boto_session is not None else boto3.Session(region_name=self._region_name)
+
+    def _get_client(self) -> Any:
+        if self._client is not None:
+            return self._client
+        self._client = self._session().client("dynamodb", config=self._make_config())
+        return self._client
+
+    def _get_s3_client(self) -> Any:
+        if self._s3_client is not None:
+            return self._s3_client
+        self._s3_client = self._session().client("s3", config=self._make_config())
+        return self._s3_client

--- a/python/src/strands_dynamodb_storage/keys.py
+++ b/python/src/strands_dynamodb_storage/keys.py
@@ -1,0 +1,48 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Storage-key normalization helpers.
+
+Behaviourally identical to the Strands SDK's internal ``_normalize_key`` /
+``_normalize_prefix`` (which are not part of the public API), reimplemented here so
+this community backend does not depend on unexported SDK internals while producing
+keys that are byte-for-byte consistent with the shipped ``Storage`` implementations.
+"""
+
+from __future__ import annotations
+
+import re
+
+from strands.types.exceptions import StorageError
+
+
+def normalize_key(key: str) -> str:
+    """Validate and normalize a storage key.
+
+    Collapses runs of ``/``, strips leading and trailing ``/``, rejects empty keys
+    and any ``..`` segment.
+
+    Raises:
+        StorageError: If the key is empty or contains a ``..`` segment.
+    """
+    normalized = re.sub(r"/+", "/", key).strip("/")
+    if not normalized:
+        raise StorageError("Storage key must not be empty")
+    if ".." in normalized.split("/"):
+        raise StorageError(f"Invalid storage key '{key}': '..' path segments are not allowed")
+    return normalized
+
+
+def normalize_prefix(prefix: str) -> str:
+    """Normalize a list prefix.
+
+    Collapses slash runs and strips leading slashes; a trailing slash is preserved
+    (it is significant for prefix matching). An empty prefix is valid.
+
+    Raises:
+        StorageError: If the prefix contains a ``..`` segment.
+    """
+    normalized = re.sub(r"/+", "/", prefix).lstrip("/")
+    if ".." in normalized.split("/"):
+        raise StorageError(f"Invalid storage prefix '{prefix}': '..' path segments are not allowed")
+    return normalized

--- a/python/src/strands_dynamodb_storage/keys.py
+++ b/python/src/strands_dynamodb_storage/keys.py
@@ -5,7 +5,7 @@
 
 Behaviourally identical to the Strands SDK's internal ``_normalize_key`` /
 ``_normalize_prefix`` (which are not part of the public API), reimplemented here so
-this community backend does not depend on unexported SDK internals while producing
+this package does not depend on unexported SDK internals while producing
 keys that are byte-for-byte consistent with the shipped ``Storage`` implementations.
 """
 

--- a/python/tests/integ/test_dynamodb_storage_integ.py
+++ b/python/tests/integ/test_dynamodb_storage_integ.py
@@ -1,0 +1,133 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Integration tests — real Amazon DynamoDB + S3 (never DynamoDB Local).
+
+Gated by RUN_INTEG=1 and AWS credentials. Provisions its own table (pk/sk) and — unless
+INTEG_S3_BUCKET is supplied — its own S3 bucket, then tears everything down.
+
+Run:
+    RUN_INTEG=1 AWS_REGION=us-east-1 .venv/bin/python -m pytest tests/integ -q
+
+Native vector search() is covered separately in test_vector_search_integ.py (it
+provisions its own vector-indexed table).
+"""
+
+from __future__ import annotations
+
+import os
+import time
+import uuid
+
+import boto3
+import pytest
+from strands.types.exceptions import StorageError
+
+from strands_dynamodb_storage import DynamoDBListQuery, DynamoDBStorage
+
+RUN = os.environ.get("RUN_INTEG") == "1"
+REGION = os.environ.get("AWS_REGION", "us-east-1")
+STAMP = f"{int(time.time())}-{uuid.uuid4().hex[:6]}"
+TABLE = os.environ.get("INTEG_TABLE", f"strands-ddb-storage-py-integ-{STAMP}")
+PROVIDED_BUCKET = os.environ.get("INTEG_S3_BUCKET")
+BUCKET = (PROVIDED_BUCKET or f"strands-ddb-storage-py-integ-{STAMP}").lower()
+
+pytestmark = pytest.mark.skipif(not RUN, reason="set RUN_INTEG=1 (needs AWS credentials) to run")
+
+_created_bucket = False
+
+
+@pytest.fixture(scope="module", autouse=True)
+def provision():
+    ddb = boto3.client("dynamodb", region_name=REGION)
+    s3 = boto3.client("s3", region_name=REGION)
+    global _created_bucket
+    ddb.create_table(
+        TableName=TABLE,
+        AttributeDefinitions=[
+            {"AttributeName": "pk", "AttributeType": "S"},
+            {"AttributeName": "sk", "AttributeType": "S"},
+        ],
+        KeySchema=[{"AttributeName": "pk", "KeyType": "HASH"}, {"AttributeName": "sk", "KeyType": "RANGE"}],
+        BillingMode="PAY_PER_REQUEST",
+    )
+    ddb.get_waiter("table_exists").wait(TableName=TABLE)
+    ddb.update_time_to_live(TableName=TABLE, TimeToLiveSpecification={"AttributeName": "expireAt", "Enabled": True})
+    if not PROVIDED_BUCKET:
+        kwargs = {"Bucket": BUCKET}
+        if REGION != "us-east-1":
+            kwargs["CreateBucketConfiguration"] = {"LocationConstraint": REGION}
+        s3.create_bucket(**kwargs)
+        _created_bucket = True
+    yield
+    try:
+        ddb.delete_table(TableName=TABLE)
+    except Exception:
+        pass
+    if _created_bucket:
+        try:
+            token = None
+            while True:
+                resp = s3.list_objects_v2(Bucket=BUCKET, **({"ContinuationToken": token} if token else {}))
+                for obj in resp.get("Contents", []):
+                    s3.delete_object(Bucket=BUCKET, Key=obj["Key"])
+                if not resp.get("IsTruncated"):
+                    break
+                token = resp.get("NextContinuationToken")
+            s3.delete_bucket(Bucket=BUCKET)
+        except Exception:
+            pass
+
+
+def store(**kw) -> DynamoDBStorage:
+    return DynamoDBStorage(TABLE, region_name=REGION, **kw)
+
+
+async def test_point_ops_and_list_and_namespace():
+    s = store()
+    base = f"sessions/pt-{STAMP}"
+    await s.write(f"{base}/a", b"hello")
+    assert await s.read(f"{base}/a") == b"hello"
+    await s.write(f"{base}/b", b"two")
+    assert await s.list(DynamoDBListQuery(pk=base)) == [f"{base}/a", f"{base}/b"]
+    view = s.namespace(base)
+    await view.write("scopes/agent/x", b"v")
+    assert await view.read("scopes/agent/x") == b"v"
+    assert await s.read(f"{base}/scopes/agent/x") == b"v"
+    await s.delete(f"{base}/a")
+    assert await s.read(f"{base}/a") is None
+
+
+async def test_s3_offload_and_compression():
+    s = store(s3_bucket=BUCKET, compression="gzip")
+    big = b"A" * 800_000  # compressible -> should stay inline
+    await s.write(f"sessions/z-{STAMP}/inline", big)
+    assert await s.read(f"sessions/z-{STAMP}/inline") == big
+    payload = os.urandom(400_001)  # incompressible -> offloads to S3
+    await s.write(f"sessions/z-{STAMP}/big", payload)
+    assert await s.read(f"sessions/z-{STAMP}/big") == payload
+    await s.delete(f"sessions/z-{STAMP}/big")
+
+
+async def test_ttl_stamp_and_filter():
+    s = store(ttl_seconds=3600)
+    pk = f"sessions/ttl-{STAMP}"
+    await s.write(f"{pk}/live", b"L")
+    await s.write(f"{pk}/dead", b"D", ttl_seconds=-1)
+    assert await s.read(f"{pk}/dead") is None
+    assert await s.list(DynamoDBListQuery(pk=pk)) == [f"{pk}/live"]
+
+
+async def test_oversized_without_bucket_raises():
+    with pytest.raises(StorageError, match="s3_bucket"):
+        await store().write(f"sessions/nb-{STAMP}/big", b"Z" * 400_001)
+
+
+async def test_cross_tenant_isolation():
+    a = store(prefix=f"tenant-a-{STAMP}")
+    b = store(prefix=f"tenant-b-{STAMP}")
+    await a.write("sessions/s1/secret", b"a-data")
+    await b.write("sessions/s1/secret", b"b-data")
+    assert await a.read("sessions/s1/secret") == b"a-data"
+    assert await b.read("sessions/s1/secret") == b"b-data"
+    assert await b.list("sessions/s1/") == ["sessions/s1/secret"]

--- a/python/tests/integ/test_vector_search_integ.py
+++ b/python/tests/integ/test_vector_search_integ.py
@@ -52,9 +52,7 @@ def vector_table():
             {
                 "IndexName": INDEX,
                 "VectorAttribute": {"AttributeName": "vector"},
-                "SearchSchema": [
-                    {"AttributeName": "pk", "SearchSchemaElementType": "HASH"}
-                ],
+                "SearchSchema": [{"AttributeName": "pk", "SearchSchemaElementType": "HASH"}],
                 "Projection": {"ProjectionType": "ALL"},
                 "Dimensions": 4,
                 "DistanceFunction": "COSINE",
@@ -95,7 +93,5 @@ async def test_native_search_end_to_end(vector_table):
     assert results[0].score <= results[1].score  # COSINE distance: lower is closer
 
     # include_values round-trips the stored bytes
-    [top] = await storage.search(
-        SearchQuery(vector=[1.0, 0.0, 0.0, 0.0], top_k=1, pk="tenant/a", include_values=True)
-    )
+    [top] = await storage.search(SearchQuery(vector=[1.0, 0.0, 0.0, 0.0], top_k=1, pk="tenant/a", include_values=True))
     assert top.data == b"likes window seats"

--- a/python/tests/integ/test_vector_search_integ.py
+++ b/python/tests/integ/test_vector_search_integ.py
@@ -1,0 +1,101 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Integration test for native vector search — real Amazon DynamoDB.
+
+Gated by RUN_INTEG=1 and AWS credentials. Provisions its own table with a
+vector index (SearchSchema HASH on pk so searches can be partition-pinned),
+waits for the index to finish backfilling, then exercises the native
+``search()`` path end to end. Tears the table down afterwards.
+
+Run:
+    RUN_INTEG=1 AWS_REGION=us-east-1 .venv/bin/python -m pytest tests/integ -q
+"""
+
+from __future__ import annotations
+
+import os
+import time
+import uuid
+
+import boto3
+import pytest
+
+from strands_dynamodb_storage import DynamoDBStorage, SearchQuery
+
+RUN = os.environ.get("RUN_INTEG") == "1"
+REGION = os.environ.get("AWS_REGION", "us-east-1")
+TABLE = f"strands-integ-vector-{int(time.time())}-{uuid.uuid4().hex[:6]}"
+INDEX = "vector_index"
+
+pytestmark = [
+    pytest.mark.skipif(not RUN, reason="integ tests run only with RUN_INTEG=1"),
+    pytest.mark.asyncio,
+]
+
+
+@pytest.fixture(scope="module")
+def vector_table():
+    client = boto3.client("dynamodb", region_name=REGION)
+    client.create_table(
+        TableName=TABLE,
+        BillingMode="PAY_PER_REQUEST",
+        AttributeDefinitions=[
+            {"AttributeName": "pk", "AttributeType": "S"},
+            {"AttributeName": "sk", "AttributeType": "S"},
+        ],
+        KeySchema=[
+            {"AttributeName": "pk", "KeyType": "HASH"},
+            {"AttributeName": "sk", "KeyType": "RANGE"},
+        ],
+        VectorIndexes=[
+            {
+                "IndexName": INDEX,
+                "VectorAttribute": {"AttributeName": "vector"},
+                "SearchSchema": [
+                    {"AttributeName": "pk", "SearchSchemaElementType": "HASH"}
+                ],
+                "Projection": {"ProjectionType": "ALL"},
+                "Dimensions": 4,
+                "DistanceFunction": "COSINE",
+            }
+        ],
+    )
+    client.get_waiter("table_exists").wait(TableName=TABLE)
+    # ACTIVE alone is not ready: wait until Backfilling is false/absent.
+    deadline = time.time() + 600
+    while time.time() < deadline:
+        indexes = client.describe_table(TableName=TABLE)["Table"].get("VectorIndexes", [])
+        idx = next((i for i in indexes if i.get("IndexName") == INDEX), None)
+        if idx and idx.get("IndexStatus") == "ACTIVE" and not idx.get("Backfilling", False):
+            break
+        time.sleep(5)
+    else:
+        pytest.fail("vector index did not become ready within 600s")
+    yield client
+    client.delete_table(TableName=TABLE)
+
+
+async def test_native_search_end_to_end(vector_table):
+    storage = DynamoDBStorage(TABLE, region_name=REGION, prefix="tenant/a/", index_name=INDEX)
+    await storage.write("memories/m1", b"likes window seats", vector=[1.0, 0.0, 0.0, 0.0], metadata={"kind": "pref"})
+    await storage.write("memories/m2", b"allergic to peanuts", vector=[0.0, 1.0, 0.0, 0.0])
+
+    # The index is eventually consistent: poll until both items are visible.
+    deadline = time.time() + 300
+    results = []
+    while time.time() < deadline:
+        results = await storage.search(SearchQuery(vector=[1.0, 0.0, 0.0, 0.0], top_k=2, pk="tenant/a"))
+        if len(results) == 2:
+            break
+        time.sleep(5)
+    assert len(results) == 2, "expected both items in search results within 300s"
+    assert results[0].key == "memories/m1"  # nearest first
+    assert results[0].metadata == {"kind": "pref"}
+    assert results[0].score <= results[1].score  # COSINE distance: lower is closer
+
+    # include_values round-trips the stored bytes
+    [top] = await storage.search(
+        SearchQuery(vector=[1.0, 0.0, 0.0, 0.0], top_k=1, pk="tenant/a", include_values=True)
+    )
+    assert top.data == b"likes window seats"

--- a/python/tests/test_dynamodb_storage.py
+++ b/python/tests/test_dynamodb_storage.py
@@ -529,7 +529,7 @@ def test_namespace_forwards_session_and_config():
 async def test_cross_tenant_isolation(aws):
     # Two tenants scoped by a constructor-bound prefix. The same logical key must
     # resolve to physically distinct partitions, and neither tenant can read or list
-    # into the other's data — the isolation guarantee reviewed by AppSec.
+    # into the other's data, which is the isolation guarantee this backend must hold.
     a = make(aws, prefix="tenant-a")
     b = make(aws, prefix="tenant-b")
     await a.write("sessions/s1/secret", b"a-data")

--- a/python/tests/test_dynamodb_storage.py
+++ b/python/tests/test_dynamodb_storage.py
@@ -1,0 +1,617 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for DynamoDBStorage, using moto for offline DynamoDB + S3."""
+
+from __future__ import annotations
+
+import math
+import time
+from unittest import mock
+
+import boto3
+import pytest
+from moto import mock_aws
+from strands.types.exceptions import StorageError
+
+from strands_dynamodb_storage import DynamoDBListQuery, DynamoDBStorage, SearchQuery
+
+REGION = "us-east-1"
+TABLE = "test-table"
+BUCKET = "test-bucket"
+SENTINEL = "\u0000"
+
+
+@pytest.fixture
+def aws():
+    with mock_aws():
+        ddb = boto3.client("dynamodb", region_name=REGION)
+        ddb.create_table(
+            TableName=TABLE,
+            AttributeDefinitions=[
+                {"AttributeName": "pk", "AttributeType": "S"},
+                {"AttributeName": "sk", "AttributeType": "S"},
+            ],
+            KeySchema=[{"AttributeName": "pk", "KeyType": "HASH"}, {"AttributeName": "sk", "KeyType": "RANGE"}],
+            BillingMode="PAY_PER_REQUEST",
+        )
+        s3 = boto3.client("s3", region_name=REGION)
+        s3.create_bucket(Bucket=BUCKET)
+        yield ddb, s3
+
+
+def make(aws, **kw) -> DynamoDBStorage:
+    ddb, s3 = aws
+    kw.setdefault("client", ddb)
+    if kw.get("s3_bucket"):
+        kw.setdefault("s3_client", s3)
+    return DynamoDBStorage(TABLE, **kw)
+
+
+def _split(full: str) -> tuple[str, str]:
+    segs = [s for s in full.split("/") if s]
+    if len(segs) <= 1:
+        return (segs[0] if segs else full), SENTINEL
+    return "/".join(segs[:2]), ("/".join(segs[2:]) or SENTINEL)
+
+
+def raw_item(ddb, full_key: str):
+    pk, sk = _split(full_key)
+    return ddb.get_item(TableName=TABLE, Key={"pk": {"S": pk}, "sk": {"S": sk}}).get("Item")
+
+
+def s3_exists(s3, key: str) -> bool:
+    try:
+        s3.head_object(Bucket=BUCKET, Key=key)
+        return True
+    except Exception:
+        return False
+
+
+def _cosine(a, b) -> float:
+    dot = sum(x * y for x, y in zip(a, b, strict=True))
+    na = math.sqrt(sum(x * x for x in a))
+    nb = math.sqrt(sum(y * y for y in b))
+    return dot / ((na * nb) or 1)
+
+
+def cosine_adapter(ddb):
+    """Brute-force cosine over stored vectors — stands in for native SearchVectors."""
+
+    async def adapter(params):
+        resp = ddb.scan(TableName=TABLE)
+        out = []
+        for it in resp.get("Items", []):
+            if "vector" not in it:
+                continue
+            if params.get("pk") and it["pk"]["S"] != params["pk"]:
+                continue
+            vec = [float(n["N"]) for n in it["vector"]["L"]]
+            meta = None
+            if "meta" in it:
+                meta = {
+                    k: (v["S"] if "S" in v else (float(v["N"]) if "N" in v else v.get("BOOL")))
+                    for k, v in it["meta"]["M"].items()
+                }
+            out.append({"key": it["k"]["S"], "score": _cosine(params["vector"], vec), "metadata": meta})
+        out.sort(key=lambda r: r["score"], reverse=True)
+        return out[: params["top_k"]]
+
+    return adapter
+
+
+# --------------------------------------------------------------------- point ops
+
+
+async def test_round_trip_and_overwrite(aws):
+    s = make(aws)
+    await s.write("sessions/s1/a", b"hello")
+    assert await s.read("sessions/s1/a") == b"hello"
+    await s.write("sessions/s1/a", b"world")
+    assert await s.read("sessions/s1/a") == b"world"
+
+
+async def test_missing_key_returns_none(aws):
+    assert await make(aws).read("sessions/s1/missing") is None
+
+
+async def test_delete_and_noop(aws):
+    s = make(aws)
+    await s.write("sessions/s1/a", b"x")
+    await s.delete("sessions/s1/a")
+    assert await s.read("sessions/s1/a") is None
+    await s.delete("sessions/s1/a")  # no-op
+
+
+async def test_single_segment_key(aws):
+    s = make(aws)
+    await s.write("singleton", b"one")
+    assert await s.read("singleton") == b"one"
+    await s.delete("singleton")
+    assert await s.read("singleton") is None
+
+
+async def test_rejects_empty_and_traversal_keys(aws):
+    s = make(aws)
+    with pytest.raises(StorageError, match="must not be empty"):
+        await s.write("", b"x")
+    with pytest.raises(StorageError, match=r"'\.\.'"):
+        await s.read("sessions/../etc")
+
+
+# ----------------------------------------------------------------------- listing
+
+
+async def test_list_prefix_sorted(aws):
+    s = make(aws)
+    base = "sessions/s1/scopes/agent/a1/immutable_history"
+    await s.write(f"{base}/snapshot_2.json", b"2")
+    await s.write(f"{base}/snapshot_1.json", b"1")
+    await s.write(f"{base}/snapshot_3.json", b"3")
+    assert await s.list(f"{base}/") == [f"{base}/snapshot_1.json", f"{base}/snapshot_2.json", f"{base}/snapshot_3.json"]
+
+
+async def test_list_structured_query_and_between_and_start_after(aws):
+    s = make(aws)
+    pk = "sessions/s1"
+    for n in ["1", "2", "3", "4"]:
+        await s.write(f"{pk}/k/{n}", n.encode())
+    assert sorted(await s.list(DynamoDBListQuery(pk=pk))) == [f"{pk}/k/{n}" for n in ["1", "2", "3", "4"]]
+    assert await s.list(DynamoDBListQuery(pk=pk, sk_between=("k/2", "k/3"))) == [f"{pk}/k/2", f"{pk}/k/3"]
+    assert await s.list(DynamoDBListQuery(pk=pk, start_after=f"{pk}/k/2")) == [f"{pk}/k/3", f"{pk}/k/4"]
+
+
+async def test_list_rejects_broad_prefix_and_dual_sk(aws):
+    s = make(aws)
+    with pytest.raises(StorageError, match="too broad"):
+        await s.list("sessions/")
+    with pytest.raises(StorageError, match="not both"):
+        await s.list(DynamoDBListQuery(pk="x/y", sk_prefix="a", sk_between=("a", "b")))
+
+
+# -------------------------------------------------------------------- S3 offload
+
+
+async def test_s3_offload_round_trip_and_cleanup(aws):
+    _, s3 = aws
+    s = make(aws, s3_bucket=BUCKET)
+    payload = b"Z" * 400_001
+    await s.write("sessions/s1/big", payload)
+    item = raw_item(aws[0], "sessions/s1/big")
+    assert item["s3"]["BOOL"] is True and "data" not in item
+    assert s3_exists(s3, "sessions/s1/big")
+    assert await s.read("sessions/s1/big") == payload
+    await s.delete("sessions/s1/big")
+    assert not s3_exists(s3, "sessions/s1/big")
+    assert await s.read("sessions/s1/big") is None
+
+
+async def test_oversized_without_bucket_raises(aws):
+    with pytest.raises(StorageError, match="s3_bucket"):
+        await make(aws).write("sessions/s1/big", b"Z" * 400_001)
+
+
+async def test_small_value_inline(aws):
+    _, s3 = aws
+    s = make(aws, s3_bucket=BUCKET)
+    await s.write("sessions/s1/small", b"tiny")
+    assert not s3_exists(s3, "sessions/s1/small")
+    assert await s.read("sessions/s1/small") == b"tiny"
+
+
+# ------------------------------------------------------------------- compression
+
+
+async def test_gzip_inline(aws):
+    s = make(aws, compression="gzip")
+    original = b"A" * 5000
+    await s.write("sessions/s1/big", original)
+    item = raw_item(aws[0], "sessions/s1/big")
+    assert item["z"]["BOOL"] is True
+    assert len(item["data"]["B"]) < 5000
+    assert await s.read("sessions/s1/big") == original
+
+
+async def test_large_compressible_stays_inline(aws):
+    _, s3 = aws
+    s = make(aws, compression="gzip", s3_bucket=BUCKET)
+    original = b"A" * 800_000
+    await s.write("sessions/s1/big", original)
+    assert not s3_exists(s3, "sessions/s1/big")  # cost win
+    assert raw_item(aws[0], "sessions/s1/big")["z"]["BOOL"] is True
+    assert await s.read("sessions/s1/big") == original
+
+
+async def test_no_shrink_stored_uncompressed(aws):
+    s = make(aws, compression="gzip")
+    await s.write("sessions/s1/tiny", b"hi")
+    assert "z" not in raw_item(aws[0], "sessions/s1/tiny")
+    assert await s.read("sessions/s1/tiny") == b"hi"
+
+
+async def test_reader_without_compression_reads_compressed(aws):
+    writer = make(aws, compression="gzip")
+    await writer.write("sessions/s1/a", b"A" * 2000)
+    reader = make(aws)  # compression off
+    assert await reader.read("sessions/s1/a") == b"A" * 2000
+
+
+async def test_incompressible_offloads(aws):
+    import os
+
+    _, s3 = aws
+    s = make(aws, compression="gzip", s3_bucket=BUCKET)
+    payload = os.urandom(400_001)
+    await s.write("sessions/s1/big", payload)
+    assert s3_exists(s3, "sessions/s1/big")
+    assert await s.read("sessions/s1/big") == payload
+
+
+# --------------------------------------------------------------------------- TTL
+
+
+async def test_ttl_stamps_future_expiry(aws):
+    s = make(aws, ttl_seconds=3600)
+    before = int(time.time())
+    await s.write("sessions/s1/a", b"v")
+    exp = int(raw_item(aws[0], "sessions/s1/a")["expireAt"]["N"])
+    assert exp >= before + 3600
+
+
+async def test_no_ttl_when_disabled(aws):
+    s = make(aws)
+    await s.write("sessions/s1/a", b"v")
+    assert "expireAt" not in raw_item(aws[0], "sessions/s1/a")
+
+
+async def test_per_write_ttl_override(aws):
+    s = make(aws, ttl_seconds=60)
+    before = int(time.time())
+    await s.write("sessions/s1/a", b"v", ttl_seconds=7200)
+    assert int(raw_item(aws[0], "sessions/s1/a")["expireAt"]["N"]) >= before + 7200
+
+
+async def test_custom_ttl_attribute(aws):
+    s = make(aws, ttl_seconds=60, ttl_attribute="ttl")
+    await s.write("sessions/s1/a", b"v")
+    item = raw_item(aws[0], "sessions/s1/a")
+    assert "ttl" in item and "expireAt" not in item
+
+
+async def test_ttl_read_and_list_filter(aws):
+    s = make(aws, ttl_seconds=3600)
+    await s.write("sessions/s1/live", b"L")
+    await s.write("sessions/s1/dead", b"D", ttl_seconds=-1)
+    assert await s.read("sessions/s1/dead") is None
+    assert await s.list(DynamoDBListQuery(pk="sessions/s1")) == ["sessions/s1/live"]
+
+
+async def test_ttl_opt_in_reader_without_ttl_returns_item(aws):
+    writer = make(aws, ttl_seconds=3600)
+    await writer.write("sessions/s1/a", b"v", ttl_seconds=-1)
+    reader = make(aws)  # no ttl -> no filter
+    assert await reader.read("sessions/s1/a") == b"v"
+
+
+async def test_no_stamp_without_ttl_even_with_override(aws):
+    s = make(aws)
+    await s.write("sessions/s1/a", b"v", ttl_seconds=60)
+    assert "expireAt" not in raw_item(aws[0], "sessions/s1/a")
+
+
+# --------------------------------------------------------------------- namespace
+
+
+async def test_constructor_prefix_transparent(aws):
+    s = make(aws, prefix="tenant-x")
+    await s.write("sessions/s1/a", b"v")
+    assert await s.read("sessions/s1/a") == b"v"
+    assert await s.list("sessions/s1/") == ["sessions/s1/a"]
+    assert raw_item(aws[0], "tenant-x/sessions/s1/a") is not None
+
+
+async def test_namespace_view(aws):
+    s = make(aws)
+    view = s.namespace("sessions/s1")
+    await view.write("scopes/agent/a1/x", b"v")
+    assert await view.read("scopes/agent/a1/x") == b"v"
+    assert await s.read("sessions/s1/scopes/agent/a1/x") == b"v"
+    assert await view.list("scopes/agent/a1/") == ["scopes/agent/a1/x"]
+
+
+def test_namespace_region_config_composes():
+    s = DynamoDBStorage(TABLE, region_name=REGION)
+    view = s.namespace("sessions/s1")
+    assert isinstance(view, DynamoDBStorage)
+    assert isinstance(view.namespace("scopes/a"), DynamoDBStorage)
+
+
+# ------------------------------------------------------------------ vector search
+
+
+async def test_vector_write_inline(aws):
+    s = make(aws, vector_search=cosine_adapter(aws[0]))
+    await s.write("memory/u1/m1", b"likes window seats", vector=[1, 0, 0], metadata={"kind": "pref"})
+    item = raw_item(aws[0], "memory/u1/m1")
+    assert [float(n["N"]) for n in item["vector"]["L"]] == [1.0, 0.0, 0.0]
+    assert item["meta"]["M"]["kind"]["S"] == "pref"
+    assert await s.read("memory/u1/m1") == b"likes window seats"
+
+
+async def test_search_ranking_values_metadata(aws):
+    s = make(aws, vector_search=cosine_adapter(aws[0]))
+    await s.write("memory/u1/a", b"a", vector=[1, 0, 0], metadata={"source": "profile"})
+    await s.write("memory/u1/b", b"b", vector=[0.9, 0.1, 0])
+    await s.write("memory/u1/c", b"c", vector=[0, 1, 0])
+    results = await s.search(SearchQuery(vector=[1, 0, 0], top_k=2, pk="memory/u1", include_values=True))
+    assert [r.key for r in results] == ["memory/u1/a", "memory/u1/b"]
+    assert results[0].score >= results[1].score
+    assert results[0].data == b"a"
+    assert results[0].metadata == {"source": "profile"}
+
+
+async def test_search_native_calls_search_vectors(aws):
+    """Without an adapter, search() issues DynamoDB SearchVectors natively."""
+    ddb, _ = aws
+    storage = make(aws, prefix="tenant/a/")
+    with mock.patch.object(
+        ddb,
+        "search_vectors",
+        create=True,
+        return_value={
+            "SearchResults": [
+                {
+                    "Item": {
+                        "pk": {"S": "tenant/a"},
+                        "sk": {"S": "memories/m1"},
+                        "meta": {"M": {"source": {"S": "profile"}, "rank": {"N": "2"}}},
+                    },
+                    "Score": 0.125,
+                }
+            ]
+        },
+    ) as sv:
+        results = await storage.search(SearchQuery(vector=[1.0, 0.0, 0.0], top_k=3, pk="tenant/a"))
+    request = sv.call_args.kwargs
+    assert request["TopK"] == 3
+    assert request["SearchVector"] == [{"N": "1.0"}, {"N": "0.0"}, {"N": "0.0"}]
+    assert request["SearchConditionExpression"] == "#pk = :pk"
+    assert request["ExpressionAttributeValues"] == {":pk": {"S": "tenant/a"}}
+    assert len(results) == 1
+    assert results[0].key == "memories/m1"  # namespace prefix stripped
+    assert results[0].score == 0.125
+    assert results[0].metadata == {"source": "profile", "rank": 2}
+
+
+async def test_search_native_topk_bounds(aws):
+    storage = make(aws)
+    with pytest.raises(StorageError, match="top_k"):
+        await storage.search(SearchQuery(vector=[1.0], top_k=101))
+    with pytest.raises(StorageError, match="top_k"):
+        await storage.search(SearchQuery(vector=[1.0], top_k=0))
+
+
+async def test_search_native_rejects_nonfinite_vector(aws):
+    storage = make(aws)
+    with pytest.raises(StorageError, match="non-finite"):
+        await storage.search(SearchQuery(vector=[float("nan"), 0.0], top_k=1))
+
+
+async def test_search_native_filter_overfetches_and_postfilters(aws):
+    ddb, _ = aws
+    storage = make(aws, prefix="tenant/a/")
+
+    def item(sk, source, score):
+        return {
+            "Item": {
+                "pk": {"S": "tenant/a"},
+                "sk": {"S": sk},
+                "meta": {"M": {"source": {"S": source}}},
+            },
+            "Score": score,
+        }
+
+    with mock.patch.object(
+        ddb,
+        "search_vectors",
+        create=True,
+        return_value={
+            "SearchResults": [
+                item("m1", "web", 0.1),
+                item("m2", "profile", 0.2),
+                item("m3", "profile", 0.3),
+            ]
+        },
+    ) as sv:
+        results = await storage.search(SearchQuery(vector=[1.0], top_k=2, pk="tenant/a", filter={"source": "profile"}))
+    # Over-fetched (top_k * factor, capped at 100), then post-filtered to top_k.
+    assert sv.call_args.kwargs["TopK"] == 20
+    assert [r.key for r in results] == ["m2", "m3"]
+
+
+async def test_search_native_drops_foreign_namespace_matches(aws):
+    ddb, _ = aws
+    storage = make(aws, prefix="tenant/a/")
+    with mock.patch.object(
+        ddb,
+        "search_vectors",
+        create=True,
+        return_value={
+            "SearchResults": [
+                {"Item": {"pk": {"S": "tenant/b"}, "sk": {"S": "m1"}}, "Score": 0.1},
+            ]
+        },
+    ):
+        results = await storage.search(SearchQuery(vector=[1.0], top_k=1))
+    assert results == []
+
+
+# ------------------------------------------------------------ construction/errors
+
+
+def test_rejects_both_client_and_region(aws):
+    with pytest.raises(StorageError, match="both client and region"):
+        DynamoDBStorage(TABLE, client=aws[0], region_name=REGION)
+
+
+async def test_wraps_backend_failures(aws):
+    ddb, _ = aws
+    bad = DynamoDBStorage("nonexistent-table", client=ddb)
+    with pytest.raises(StorageError):
+        await bad.write("sessions/s1/a", b"x")
+    with pytest.raises(StorageError):
+        await bad.read("sessions/s1/a")
+    with pytest.raises(StorageError):
+        await bad.delete("sessions/s1/a")
+    with pytest.raises(StorageError):
+        await bad.list(DynamoDBListQuery(pk="sessions/s1"))
+
+
+async def test_wraps_search_adapter_failure(aws):
+    async def boom(_params):
+        raise RuntimeError("adapter boom")
+
+    s = make(aws, vector_search=boom)
+    with pytest.raises(StorageError):
+        await s.search(SearchQuery(vector=[1, 0, 0], top_k=1))
+
+
+async def test_list_rejects_traversal_prefix(aws):
+    with pytest.raises(StorageError, match=r"'\.\.'"):
+        await make(aws).list("sessions/../etc")
+
+
+def test_public_exports():
+    import strands_dynamodb_storage as pkg
+
+    assert pkg.DynamoDBStorage is DynamoDBStorage
+    for name in ("DynamoDBListQuery", "SearchQuery", "SearchResult", "VectorSearchAdapter"):
+        assert hasattr(pkg, name)
+
+
+# --------------------------------------------------- AutoSDE regression coverage
+
+
+async def test_limit_with_start_after_returns_full_limit(aws):
+    # start_after must be applied during collection so a limit is filled with
+    # post-cursor keys, not truncated afterwards (would otherwise return < limit).
+    s = make(aws)
+    pk = "sessions/s1"
+    for n in ["1", "2", "3", "4", "5"]:
+        await s.write(f"{pk}/k/{n}", n.encode())
+    result = await s.list(DynamoDBListQuery(pk=pk, start_after=f"{pk}/k/1", limit=2))
+    assert result == [f"{pk}/k/2", f"{pk}/k/3"]
+
+
+async def test_limit_with_ttl_filter_returns_live_items(aws):
+    # With a TTL filter active, Limit must not be pushed to DynamoDB (it caps pre-filter
+    # evaluation), so a limit returns that many *live* items rather than under-returning.
+    s = make(aws, ttl_seconds=3600)
+    pk = "sessions/s1"
+    await s.write(f"{pk}/a_dead", b"x", ttl_seconds=-1)
+    await s.write(f"{pk}/b_live", b"x")
+    await s.write(f"{pk}/c_dead", b"x", ttl_seconds=-1)
+    await s.write(f"{pk}/d_live", b"x")
+    await s.write(f"{pk}/e_live", b"x")
+    result = await s.list(DynamoDBListQuery(pk=pk, limit=2))
+    assert result == [f"{pk}/b_live", f"{pk}/d_live"]
+
+
+def test_namespace_forwards_session_and_config():
+    session = object()
+    config = object()
+    s = DynamoDBStorage(TABLE, boto_session=session, boto_client_config=config)
+    view = s.namespace("sessions/s1")
+    assert view._boto_session is session
+    assert view._boto_client_config is config
+
+
+async def test_cross_tenant_isolation(aws):
+    # Two tenants scoped by a constructor-bound prefix. The same logical key must
+    # resolve to physically distinct partitions, and neither tenant can read or list
+    # into the other's data — the isolation guarantee reviewed by AppSec.
+    a = make(aws, prefix="tenant-a")
+    b = make(aws, prefix="tenant-b")
+    await a.write("sessions/s1/secret", b"a-data")
+    await a.write("sessions/s1/other", b"a-other")
+    await b.write("sessions/s1/secret", b"b-data")
+    assert await a.read("sessions/s1/secret") == b"a-data"
+    assert await b.read("sessions/s1/secret") == b"b-data"  # same key, isolated value
+    assert await a.list("sessions/s1/") == ["sessions/s1/other", "sessions/s1/secret"]
+    assert await b.list("sessions/s1/") == ["sessions/s1/secret"]  # cannot see tenant-a keys
+    # underlying partitions are physically distinct
+    assert raw_item(aws[0], "tenant-a/sessions/s1/secret")["data"]["B"] != b"b-data"
+
+
+async def test_structured_query_cannot_cross_namespace(aws):
+    # A DynamoDBListQuery names the partition directly, so the namespace boundary is
+    # enforced explicitly rather than by construction. Naming another tenant's
+    # partition is rejected, not silently answered with different data.
+    a = make(aws, prefix="tenant-a")
+    b = make(aws, prefix="tenant-b")
+    await a.write("sessions/s1/secret", b"a-data")
+    with pytest.raises(StorageError, match="outside this storage namespace"):
+        await b.list(DynamoDBListQuery(pk="tenant-a/sessions"))
+    # the owning instance can still query its own partition
+    assert await a.list(DynamoDBListQuery(pk="tenant-a/sessions")) == ["sessions/s1/secret"]
+
+
+async def test_structured_query_unprefixed_storage_unrestricted(aws):
+    # Without a namespace there is no boundary to enforce; naming any partition is fine.
+    s = make(aws)
+    await s.write("sessions/s1/a", b"1")
+    assert await s.list(DynamoDBListQuery(pk="sessions/s1")) == ["sessions/s1/a"]
+
+
+async def test_search_pk_cannot_cross_namespace(aws):
+    async def never_called(params):  # pragma: no cover - must not run
+        raise AssertionError("adapter must not be reached for an out-of-scope pk")
+
+    b = make(aws, prefix="tenant-b", vector_search=never_called)
+    with pytest.raises(StorageError, match="outside this storage namespace"):
+        await b.search(SearchQuery(vector=[1.0, 0.0], top_k=1, pk="tenant-a/sessions"))
+
+
+async def test_search_drops_matches_outside_namespace(aws):
+    # pk is optional, so the index can return matches from other namespaces. Those are
+    # dropped rather than de-prefixed blindly into something resembling our own key.
+    async def leaky(params):
+        return [
+            {"key": "tenant-a/sessions/s1/secret", "score": 0.99},
+            {"key": "tenant-b/sessions/s1/mine", "score": 0.98},
+        ]
+
+    b = make(aws, prefix="tenant-b", vector_search=leaky)
+    results = await b.search(SearchQuery(vector=[1.0, 0.0], top_k=2))
+    assert [r.key for r in results] == ["sessions/s1/mine"]
+
+
+async def test_list_drops_stored_keys_outside_namespace(aws):
+    # Defence in depth on the read path: an item physically inside our partition whose
+    # stored key attribute belongs elsewhere must not be de-prefixed into our namespace.
+    ddb, _ = aws
+    b = make(aws, prefix="tenant-b")
+    await b.write("sessions/s1/mine", b"ok")
+    pk, sk = _split("tenant-b/sessions/s1/planted")
+    ddb.put_item(
+        TableName=TABLE,
+        Item={"pk": {"S": pk}, "sk": {"S": sk}, "k": {"S": "tenant-a/sessions/s1/secret"}, "data": {"B": b"x"}},
+    )
+    assert await b.list(DynamoDBListQuery(pk="tenant-b/sessions")) == ["sessions/s1/mine"]
+
+
+async def test_structured_query_rejects_prefix_confusion(aws):
+    # 'tenant' must not be treated as an ancestor of 'tenant-b/' by string prefixing.
+    b = make(aws, prefix="tenant-b")
+    with pytest.raises(StorageError, match="outside this storage namespace"):
+        await b.list(DynamoDBListQuery(pk="tenant"))
+
+
+async def test_namespaced_view_can_query_its_own_partition(aws):
+    # A deep namespace lives inside a shallower physical partition; querying it is
+    # allowed, and rows outside the namespace are filtered out.
+    s = make(aws)
+    view = s.namespace("sessions/s1")
+    await view.write("scopes/agent/a1/x", b"v")
+    await s.write("sessions/s2/other", b"sibling")
+    assert await view.list(DynamoDBListQuery(pk="sessions/s1")) == ["scopes/agent/a1/x"]

--- a/typescript/.gitignore
+++ b/typescript/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+coverage/
+*.tgz

--- a/typescript/.prettierrc
+++ b/typescript/.prettierrc
@@ -1,0 +1,8 @@
+{
+  "printWidth": 120,
+  "tabWidth": 2,
+  "semi": false,
+  "singleQuote": true,
+  "trailingComma": "es5",
+  "arrowParens": "always"
+}

--- a/typescript/LICENSE
+++ b/typescript/LICENSE
@@ -1,0 +1,175 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.

--- a/typescript/NOTICE
+++ b/typescript/NOTICE
@@ -1,0 +1,1 @@
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -1,0 +1,193 @@
+# strands-dynamodb-storage
+
+A community **Amazon DynamoDB `Storage` backend** for the [Strands Agents](https://github.com/strands-agents/harness-sdk) TypeScript SDK.
+
+It implements the SDK's unified byte `Storage` interface (`write` / `read` / `delete` / `list` / `namespace`), so one
+DynamoDB-backed instance can be passed to **Session Manager, Memory Manager**, the context offloader, transcripts, and
+any other subsystem that persists bytes — no per-subsystem code. On top of the byte contract it adds S3 offload for large
+values, optional gzip compression, TTL, and optional **native vector search**.
+
+## Install
+
+```bash
+npm install strands-dynamodb-storage @strands-agents/sdk @aws-sdk/client-dynamodb @aws-sdk/lib-dynamodb
+# only if you enable S3 offload for values above the 400 KB item limit:
+npm install @aws-sdk/client-s3
+```
+
+The AWS SDK packages are **peer dependencies** and are lazy-loaded — if you never construct a `DynamoDBStorage`, you
+don't pay for them. `@aws-sdk/client-s3` is optional (needed only when `s3Bucket` is set).
+
+## Table
+
+A table with a string partition key `pk` and string sort key `sk` (`PAY_PER_REQUEST` recommended):
+
+```bash
+aws dynamodb create-table --table-name agent-data \
+  --attribute-definitions AttributeName=pk,AttributeType=S AttributeName=sk,AttributeType=S \
+  --key-schema AttributeName=pk,KeyType=HASH AttributeName=sk,KeyType=RANGE \
+  --billing-mode PAY_PER_REQUEST --region us-east-1
+```
+
+## Quick start — session persistence, zero custom code
+
+```ts
+import { Agent, SessionManager } from '@strands-agents/sdk'
+import { DynamoDBStorage } from 'strands-dynamodb-storage'
+
+const storage = new DynamoDBStorage('agent-data', { region: 'us-east-1' })
+const agent = new Agent({ sessionManager: new SessionManager({ storage }) })
+// sessions now persist to DynamoDB — nothing else to wire.
+```
+
+## Direct byte usage
+
+```ts
+import { DynamoDBStorage } from 'strands-dynamodb-storage'
+
+const store = new DynamoDBStorage('agent-data', { region: 'us-east-1' })
+
+await store.write('sessions/s1/snapshot.json', new TextEncoder().encode('{"turn":1}'))
+const bytes = await store.read('sessions/s1/snapshot.json')   // Uint8Array | null
+
+// list by string prefix -> a native partition Query with begins_with
+const keys = await store.list('sessions/s1/')
+
+// or a structured DynamoDB query (the intended pk/sk extension point) — no GSI
+const scoped = await store.list({ pk: 'sessions/s1', skPrefix: 'scopes/agent/' })
+
+await store.delete('sessions/s1/snapshot.json')
+
+// namespaced view (keys transparently prefixed); nesting composes
+const s1 = store.namespace('sessions/s1')
+await s1.write('scopes/agent/a1/x', bytes ?? new Uint8Array())
+```
+
+Keys are opaque `/`-separated paths. The leading two segments become the partition key and the remainder the sort key,
+so point operations are single-item `PutItem`/`GetItem`/`DeleteItem` and listing is a partition-scoped `Query`.
+
+## Large values → S3 offload (optional)
+
+```ts
+const store = new DynamoDBStorage('agent-data', {
+  region: 'us-east-1',
+  s3Bucket: 'my-agent-offload-bucket',   // values > ~380 KB go to S3; a pointer item stays in DynamoDB
+})
+```
+
+Reads and deletes are transparent (the pointer is followed / the S3 object is cleaned up). Without `s3Bucket`, an
+oversized write throws rather than silently truncating.
+
+## Compression (optional)
+
+```ts
+new DynamoDBStorage('agent-data', { region: 'us-east-1', compression: 'gzip' })
+```
+
+Transparent gzip applied **before** the offload size check, so compressible values stay inline in DynamoDB (lower cost,
+fewer S3 round-trips). Each item records whether it was compressed, so reads are correct regardless of the current
+setting; values that don't shrink are stored uncompressed.
+
+## TTL (optional)
+
+```ts
+new DynamoDBStorage('agent-data', { region: 'us-east-1', ttlSeconds: 86_400 })  // 1 day
+// per-write override:
+await store.write('sessions/tmp/x', data, { ttlSeconds: 3_600 })
+```
+
+Stamps a DynamoDB-native epoch-seconds `expireAt` attribute (enable TTL on that attribute at the table level for physical
+cleanup). `read`/`list` also filter items whose expiry has passed, covering the lag before DynamoDB physically deletes
+them. With S3 offload, add an S3 lifecycle rule to reclaim offloaded objects (TTL removes only the DynamoDB pointer).
+
+## Vector search — DynamoDB native vector index
+
+`search()` is an optional, feature-detected part of the `Storage` contract: consumers do `if (storage.search) { … }` and
+fall back to client-side KNN when a backend doesn't implement it. On DynamoDB it runs against the **native vector index**,
+so nearest-neighbour scoring happens *in the database*.
+
+Write an embedding alongside the bytes, then query:
+
+```ts
+import { DynamoDBStorage, type VectorSearchAdapter } from 'strands-dynamodb-storage'
+
+const store = new DynamoDBStorage('agent-memory', {
+  region: 'us-east-1',
+  indexName: 'vector_index',        // vector index on the table
+  vectorAttribute: 'vector',
+  vectorSearch: myAdapter,          // adapter that issues DynamoDB SearchVectors (see below)
+})
+
+// store a memory with its embedding (kept inline even when the payload offloads to S3)
+await store.write('memory/u1/m1', new TextEncoder().encode('likes window seats'), {
+  vector: [/* embedding, e.g. 1024 floats */],
+  metadata: { kind: 'preference' },
+})
+
+// nearest-neighbour search, scoped to a partition
+const results = await store.search({
+  vector: queryEmbedding,
+  topK: 5,
+  pk: 'memory/u1',          // required: the index HASH key
+  filter: { kind: 'preference' },   // optional server-side metadata filter
+  includeValues: true,      // hydrate each match's stored bytes
+})
+// results: Array<{ key: string; score: number; data?: Uint8Array; metadata?: Record<string, unknown> }>
+// ordered nearest-first; score is higher = nearer.
+```
+
+### The `vectorSearch` adapter (optional override)
+
+`search()` issues DynamoDB `SearchVectors` natively (requires `@aws-sdk/client-dynamodb` >= 3.1103.0).
+A `vectorSearch` adapter, when configured, **overrides** the native call — useful for testing or custom
+routing. The adapter has the shape:
+
+```ts
+type VectorSearchAdapter = (params: {
+  tableName: string
+  indexName: string
+  vectorAttribute: string
+  pk?: string
+  vector: number[]
+  topK: number
+  filter?: Record<string, string | number | boolean>
+}) => Promise<Array<{ key: string; score: number; metadata?: Record<string, unknown> }>>
+```
+
+At GA this becomes a ~10-line wrapper over `SearchVectorsCommand`. Until then, provide your own adapter (or use the
+reference recipe) — without one, `search()` throws a clear error instead of silently degrading.
+
+## Configuration reference
+
+| Option | Purpose |
+|--------|---------|
+| `region` / `client` | AWS region, or a pre-built `DynamoDBDocumentClient` (mutually exclusive) |
+| `prefix` | Key prefix prepended to every key (a namespace within the table) |
+| `s3Bucket` / `s3Prefix` / `s3Client` | S3 offload target for large values |
+| `compression` | `'gzip'` \| `'none'` (default `'none'`) |
+| `ttlSeconds` / `ttlAttribute` | TTL duration + attribute name (default `expireAt`) |
+| `indexName` / `vectorAttribute` | Vector index + embedding attribute (default `vector_index` / `vector`) |
+| `vectorSearch` | Adapter that performs the native vector search |
+
+## Minimal IAM
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    { "Effect": "Allow",
+      "Action": ["dynamodb:GetItem","dynamodb:PutItem","dynamodb:DeleteItem","dynamodb:Query"],
+      "Resource": "arn:aws:dynamodb:us-east-1:ACCOUNT:table/agent-data" },
+    { "Effect": "Allow",
+      "Action": ["s3:GetObject","s3:PutObject","s3:DeleteObject"],
+      "Resource": "arn:aws:s3:::my-agent-offload-bucket/*" }
+  ]
+}
+```
+
+(The S3 statement is only needed when `s3Bucket` is configured. Vector `search()` additionally needs the DynamoDB
+vector-search action on the table/index once that API is generally available.)
+
+## License
+
+Apache-2.0

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -1,6 +1,6 @@
 # strands-dynamodb-storage
 
-A community **Amazon DynamoDB `Storage` backend** for the [Strands Agents](https://github.com/strands-agents/harness-sdk) TypeScript SDK.
+An **Amazon DynamoDB `Storage` backend** for the [Strands Agents](https://github.com/strands-agents/harness-sdk) TypeScript SDK.
 
 It implements the SDK's unified byte `Storage` interface (`write` / `read` / `delete` / `list` / `namespace`), so one
 DynamoDB-backed instance can be passed to **Session Manager, Memory Manager**, the context offloader, transcripts, and

--- a/typescript/eslint.config.js
+++ b/typescript/eslint.config.js
@@ -1,0 +1,32 @@
+import eslint from '@eslint/js'
+import tseslint from '@typescript-eslint/eslint-plugin'
+import tsparser from '@typescript-eslint/parser'
+import globals from 'globals'
+
+export default [
+  eslint.configs.recommended,
+  {
+    files: ['src/**/*.ts', 'test/**/*.ts'],
+    languageOptions: {
+      parser: tsparser,
+      parserOptions: {
+        ecmaVersion: 2022,
+        sourceType: 'module',
+      },
+      globals: {
+        ...globals.node,
+      },
+    },
+    plugins: {
+      '@typescript-eslint': tseslint,
+    },
+    rules: {
+      ...tseslint.configs.recommended.rules,
+      '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_', varsIgnorePattern: '^_' }],
+      '@typescript-eslint/no-explicit-any': 'warn',
+    },
+  },
+  {
+    ignores: ['dist/**', 'node_modules/**'],
+  },
+]

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,0 +1,5737 @@
+{
+  "name": "strands-dynamodb-storage",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "strands-dynamodb-storage",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "@aws-sdk/client-dynamodb": "^3.1104.0",
+        "@aws-sdk/client-s3": "^3.1092.0",
+        "@aws-sdk/client-sts": "^3.1092.0",
+        "@aws-sdk/lib-dynamodb": "^3.1104.0",
+        "@aws-sdk/util-dynamodb": "^3.996.7",
+        "@eslint/js": "^9.0.0",
+        "@strands-agents/sdk": "^1.10.0",
+        "@types/node": "^22.0.0",
+        "@typescript-eslint/eslint-plugin": "^8.0.0",
+        "@typescript-eslint/parser": "^8.0.0",
+        "@vitest/coverage-v8": "^2.1.9",
+        "eslint": "^9.0.0",
+        "globals": "^17.7.0",
+        "prettier": "^3.0.0",
+        "typescript": "^5.5.0",
+        "vitest": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-dynamodb": "^3.1103.0",
+        "@aws-sdk/client-s3": "^3.0.0",
+        "@aws-sdk/lib-dynamodb": "^3.1103.0",
+        "@aws-sdk/util-dynamodb": "^3.996.7",
+        "@strands-agents/sdk": ">=1.10.0"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/client-s3": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/checksums": {
+      "version": "3.1000.19",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/checksums/-/checksums-3.1000.19.tgz",
+      "integrity": "sha512-Hc4N100RdkuWshKBnhPzmpdftfi9mCLz+OHFELHM1QIgMH4QRUUWyWgfiebta/YX2Bd62wTcm3EqAP8TeXv0gA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.976.0",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-bedrock-runtime": {
+      "version": "3.1092.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1092.0.tgz",
+      "integrity": "sha512-BzG4OlvT8fAdJfL4/krIsg6/ek9CF0MI65nzV2D1JtFYGehuWpsc1IT39LfZzqaqLE86plWCXvk4+sLS8HtXzg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.976.0",
+        "@aws-sdk/credential-provider-node": "^3.972.71",
+        "@aws-sdk/eventstream-handler-node": "^3.972.29",
+        "@aws-sdk/middleware-eventstream": "^3.972.24",
+        "@aws-sdk/middleware-websocket": "^3.972.42",
+        "@aws-sdk/token-providers": "3.1092.0",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/fetch-http-handler": "^5.6.6",
+        "@smithy/node-http-handler": "^4.9.6",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb": {
+      "version": "3.1104.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.1104.0.tgz",
+      "integrity": "sha512-Ydt8aMkemljnYy9jlj6u1entx5k9YqeLPVngeSZdVovL/VBUX/DXO7GzgXZGHT2eV5fshXCLwZ0jHLZJAAMHYA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/credential-provider-node": "^3.972.78",
+        "@aws-sdk/dynamodb-codec": "^3.973.41",
+        "@aws-sdk/middleware-endpoint-discovery": "^3.972.27",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/node-http-handler": "^4.9.13",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3": {
+      "version": "3.1092.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1092.0.tgz",
+      "integrity": "sha512-NfcptdANQM1IgUT8QITKBN+PZPjshm5FyLKKjotEwscsDQGik4iDdLgwFYJSTlGoREv26Tf97WHpL7IZ3HF9nA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/checksums": "^3.1000.19",
+        "@aws-sdk/core": "^3.976.0",
+        "@aws-sdk/credential-provider-node": "^3.972.71",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.65",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.41",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/fetch-http-handler": "^5.6.6",
+        "@smithy/node-http-handler": "^4.9.6",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts": {
+      "version": "3.1092.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.1092.0.tgz",
+      "integrity": "sha512-EgKpb6LN/JP/3AbvxXh8c17SKsOeutJRvl3pmMdJ/jx+FqcGvYlpZdj6LVl3Y0ssv6LzbtYcMw/vIzygYRaDoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.976.0",
+        "@aws-sdk/credential-provider-node": "^3.972.71",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.41",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/fetch-http-handler": "^5.6.6",
+        "@smithy/node-http-handler": "^4.9.6",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.977.6",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.6.tgz",
+      "integrity": "sha512-QiaJV4/zDrB4ZY2mfeSXSzSTc36W16sZXcGz+SPFk0CJ26gziO0cS+4LjJUMAbdeeBOvS0k0Aq1cZpfGdUXxSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/xml-builder": "^3.972.37",
+        "@aws/lambda-invoke-store": "^0.3.0",
+        "@smithy/core": "^3.31.1",
+        "@smithy/signature-v4": "^5.6.12",
+        "@smithy/types": "^4.16.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.67",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.67.tgz",
+      "integrity": "sha512-rcIpk5kxUqDaaNa6Xk23pQ6ViY7jlqzmfFWCahQcBT97ddXaXYYwzCen9Tz1Jvo6aJft6wDl5bN44/Jw5B4oLA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.69",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.69.tgz",
+      "integrity": "sha512-nggwJtZ4eeNsUw5IeWBMXsi1ryct5idi0K+/SCRF3kybLubOMaNTb3XCihXpWMiVpyzyPeIrl0zTkzhBH9porA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/node-http-handler": "^4.9.13",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.973.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.12.tgz",
+      "integrity": "sha512-pNEf/OeyN5X3VmLKlgSO6TqaWmW10CvI3TfwL1XhsuhYjSLT2VDaxFnCPHnOeQXSaFisMX4jNhpETriqN8DOmg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/credential-provider-env": "^3.972.67",
+        "@aws-sdk/credential-provider-http": "^3.972.69",
+        "@aws-sdk/credential-provider-login": "^3.972.74",
+        "@aws-sdk/credential-provider-process": "^3.972.67",
+        "@aws-sdk/credential-provider-sso": "^3.973.11",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.73",
+        "@aws-sdk/nested-clients": "^3.997.41",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/credential-provider-imds": "^4.4.16",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.74",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.74.tgz",
+      "integrity": "sha512-0AQfDcf99TNmqVKv0owHrw/TQs6i4ZE5t9qmz6NvO53bE/sA/tpXhXL9AAcEP1qHc6Zzjd1UMb69+/9zdhvY3g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/nested-clients": "^3.997.41",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.78",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.78.tgz",
+      "integrity": "sha512-OgPAnfvbGAMWac6yvxJ1ihslrvDpPVwR68D2csospdNCCyPvHk9JLzYKwz48SNiS1T2znDwHauywRKRFfpyYng==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.67",
+        "@aws-sdk/credential-provider-http": "^3.972.69",
+        "@aws-sdk/credential-provider-ini": "^3.973.12",
+        "@aws-sdk/credential-provider-process": "^3.972.67",
+        "@aws-sdk/credential-provider-sso": "^3.973.11",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.73",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/credential-provider-imds": "^4.4.16",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.67",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.67.tgz",
+      "integrity": "sha512-IlUEejorGTWKb4/Dm7K5Yw4QxUmXLThLhrvBmzVBqZFTbW72cv9LTcITmo1dsnYriALE4h68mOq4LB99x6sQ7Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.973.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.11.tgz",
+      "integrity": "sha512-gAQBkBZxUB84d71+pPcI9L+jh2ujhuAVxc/4FgGiWFDjkPBlMKxzd5XDtkSXTFX8Ro7ansnT88+XadasxMeCRw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/nested-clients": "^3.997.41",
+        "@aws-sdk/token-providers": "3.1103.0",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
+      "version": "3.1103.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1103.0.tgz",
+      "integrity": "sha512-N4wy26MNn31ItGVHYHPrEuCIFY4MBBjC+C5v1lJKqIUSA7OZBdhleCY53zCCrXn27hsk7YNOaTuhQu807S4AfQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/nested-clients": "^3.997.41",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.73",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.73.tgz",
+      "integrity": "sha512-SnlEmQa6SjOgs6iOPLUQl1Eyq4AKiAdPQlkOhFhqNfDtDCwibMGvL6QlkSmf3o6vAUSImzdPCxowT5dfQUZP1A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/nested-clients": "^3.997.41",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/dynamodb-codec": {
+      "version": "3.973.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/dynamodb-codec/-/dynamodb-codec-3.973.41.tgz",
+      "integrity": "sha512-N4go/LzYFd6KJ+r7qqAjzmsw85PFN99RnDYZvw22FzU3VZgL5+umvncfu0M7hlzeIUKHSLL65HTJIXiLY7RJFg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.6",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/endpoint-cache": {
+      "version": "3.972.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/endpoint-cache/-/endpoint-cache-3.972.9.tgz",
+      "integrity": "sha512-LFvdgq8SriaskUcjpBMDE7J2c9RmuT5v3gU36/znV71EU5DKUis4FmGFjCMelKCCViFeVrQADBAlIiOYRhEx6Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mnemonist": "0.38.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/eventstream-handler-node": {
+      "version": "3.972.29",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.29.tgz",
+      "integrity": "sha512-t3tKQRTVXsI2QNPE3CaNjHl0wRO9Xi3acZkAyti2RQsiFmZ9Gi0kArX2ighlRJ1BtDVuul413gThAgzyTfgmWA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/lib-dynamodb": {
+      "version": "3.1104.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-dynamodb/-/lib-dynamodb-3.1104.0.tgz",
+      "integrity": "sha512-6K6aqTU1ML/nbkibWC26qOapbndl5pZ/Is1nujFQjWTZGieQt02arnF6vQrZbLAqu0Z5u0R8u/mB2BxR6gArOg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/util-dynamodb": "^3.996.7",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-dynamodb": "^3.1104.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-endpoint-discovery": {
+      "version": "3.972.27",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.972.27.tgz",
+      "integrity": "sha512-5AJlxrsg27IGGiQauWOdVyqK55EN0EMIwXndkVHhBiPT4CtdSaz89/sAENSw+GP4KF+BOWcgycZFNjkOLmfo1A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/endpoint-cache": "^3.972.9",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-eventstream": {
+      "version": "3.972.24",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.24.tgz",
+      "integrity": "sha512-oykin4mDWxNOuYQ7SF1cHzgYeuFEkF4cdRwgvjFFbIklkx09qIFBiOgsORafG9sXZFO3TayMmQuAQYgADXhI8w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3": {
+      "version": "3.972.65",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.65.tgz",
+      "integrity": "sha512-udwNhRfDTfCB98mAHjjgsnKQlxygB4e0X+Obne/XjJpvVsF0YCQC8ZErd/8Z6IPoLQjtiKHzwqEDbZiLrJEnOg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.976.0",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.41",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-websocket": {
+      "version": "3.972.42",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.42.tgz",
+      "integrity": "sha512-dw+GP8DC7QC2C8tUoK7DI8BnrNAjz8tb+uBHSrD2qJvxkCf58kTtFr98pljSrk+umU4n4HDW4eU2k7C2dWMzsg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.976.0",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/fetch-http-handler": "^5.6.6",
+        "@smithy/signature-v4": "^5.6.5",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.41.tgz",
+      "integrity": "sha512-RDHqPGQWlF6tatA/Tp3rg6oIwtgN9IVderxE+9av2Y93Dfyu+mO1hZ5Bu2jpfZg2rwdNbsssnwM+sLafIczMlQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.43",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/node-http-handler": "^4.9.13",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.43",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.43.tgz",
+      "integrity": "sha512-lKekx8bLBXSv4O+cslk9Zfnw2XKSkWBs3uWL5QGhH2ZAQfNS7FE0vcSSN2vD/AhxX54ZTywWxR4STThoeOXlBA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/signature-v4": "^5.6.12",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1092.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1092.0.tgz",
+      "integrity": "sha512-hBYUAr6iBLNFcsiWTgtBb0stdSw39VOUq4Sp4A5caCNf66BAZplWN4FleKrVpJx5li2YgdnK2DqoFSMWC642FQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.976.0",
+        "@aws-sdk/nested-clients": "^3.997.34",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.974.2",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.2.tgz",
+      "integrity": "sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-dynamodb": {
+      "version": "3.996.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-dynamodb/-/util-dynamodb-3.996.7.tgz",
+      "integrity": "sha512-v+WJASG9yaW8qNM7pNSgH1PBYz5mVTf7gzKPi0NqGjLlaCtPdk6EjM1lmv03egA07iXUw6OToGYfW2w8D3kBrg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-dynamodb": "^3.1088.0"
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.37",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.37.tgz",
+      "integrity": "sha512-zKq4HQum8JwDyEuyfuI4bbiAcU0KxP6qy+9PR/IsR92IyE/DaBAikzAS50tjxip4bqIIANpCcG+Yyj6CVhXupg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz",
+      "integrity": "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.10.1.tgz",
+      "integrity": "sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.7",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.5"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@eslint/config-array/node_modules/brace-expansion": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.6.tgz",
+      "integrity": "sha512-l2Ul9PrHsPCKcEY/ac7VgFj9D80C7S68sOKc618SyHDPK36s1XcFebXY0iTzUVn4Yq+YbwvSnDmCz9yxjX+QrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.14.0",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.3.0",
+        "minimatch": "^3.1.5",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@eslint/eslintrc/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.5.tgz",
+      "integrity": "sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
+      "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
+      "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
+      "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
+      "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
+      "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
+      "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
+      "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
+      "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
+      "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
+      "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
+      "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
+      "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
+      "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
+      "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
+      "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
+      "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
+      "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
+      "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
+      "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
+      "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
+      "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
+      "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
+      "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@smithy/core": {
+      "version": "3.31.1",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.31.1.tgz",
+      "integrity": "sha512-CyogUINxvi7C7LDsh8Syo6hVJOT9ckz4rG8dRZfTJ8r91HkMY59PnNooaj7WcHyxEkxPfBAmbgztZU+xTo76lg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.4.16",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.16.tgz",
+      "integrity": "sha512-QfuLWAkLzptffFW980AFeHZFdqds2B64rpEd3uJ6lgs3xVn9QegGMUgUcj+4d7dRrAsya3r58ZKpku97WcFb4w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.6.13",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.13.tgz",
+      "integrity": "sha512-4fW86pEUOMbrD5nkbyl/tTvPHHWJFbuB2odl6ps9lWfHoXf9HWh3Q/Smh59qH1g7+c/BSZghX6bbUk4gsiMs8A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.9.13",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.13.tgz",
+      "integrity": "sha512-Nmd/Nl35zfYrd+a6OO2cDJb3GPh9bgTjIUhcM+JFfjpp8/osCgboDV5nCT1I01Pv6R13eSKDKLSoVa5ZB6Zsfw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.6.12",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.12.tgz",
+      "integrity": "sha512-I6KLtq3H0qqSuV9vLglfi8puHqzygzWHOnI4z/Rdoo+q50vvo18vBRdPAvvEtcaKROz7Zn6qnPa14kRfPH6PcQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.16.1.tgz",
+      "integrity": "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@strands-agents/sdk": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@strands-agents/sdk/-/sdk-1.10.0.tgz",
+      "integrity": "sha512-7KIGM+6cCgN/RbIcXFRTtLkLkdtXB57zprUvy2bZL+BO8WkhHh4Fv8DpRwTAZXZQUq37KqwmQ/DyX70Y2xTvog==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/client-bedrock-runtime": "^3.1078.0",
+        "@types/json-schema": "^7.0.15",
+        "uuid": "^14.0.1",
+        "yaml": "^2.8.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@a2a-js/sdk": "^0.3.10",
+        "@ai-sdk/provider": "^3.0.0",
+        "@anthropic-ai/sdk": "^0.109.1",
+        "@aws-sdk/client-bedrock-agent": "^3.1078.0",
+        "@aws-sdk/client-bedrock-agent-runtime": "^3.1078.0",
+        "@aws-sdk/client-s3": "^3.1078.0",
+        "@aws/bedrock-token-generator": "^1.1.0",
+        "@cedar-policy/cedar-wasm": "^4.0.0",
+        "@cedar-policy/mcp-schema-generator-wasm": "^0.6.0",
+        "@google/genai": "^2.6.0",
+        "@modelcontextprotocol/sdk": "^1.25.2",
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/exporter-metrics-otlp-http": "^0.219.0",
+        "@opentelemetry/exporter-trace-otlp-http": "^0.219.0",
+        "@opentelemetry/resources": "^2.8.0",
+        "@opentelemetry/sdk-metrics": "^2.6.1",
+        "@opentelemetry/sdk-trace-base": "^2.6.1",
+        "@opentelemetry/sdk-trace-node": "^2.6.1",
+        "@smithy/types": "^4.15.1",
+        "express": "^5.1.0",
+        "openai": "^6.45.0",
+        "zod": "^4.1.12"
+      },
+      "peerDependenciesMeta": {
+        "@a2a-js/sdk": {
+          "optional": true
+        },
+        "@ai-sdk/provider": {
+          "optional": true
+        },
+        "@anthropic-ai/sdk": {
+          "optional": true
+        },
+        "@aws-sdk/client-bedrock-agent": {
+          "optional": true
+        },
+        "@aws-sdk/client-bedrock-agent-runtime": {
+          "optional": true
+        },
+        "@aws-sdk/client-s3": {
+          "optional": true
+        },
+        "@aws/bedrock-token-generator": {
+          "optional": true
+        },
+        "@cedar-policy/cedar-wasm": {
+          "optional": true
+        },
+        "@cedar-policy/mcp-schema-generator-wasm": {
+          "optional": true
+        },
+        "@google/genai": {
+          "optional": true
+        },
+        "@opentelemetry/exporter-metrics-otlp-http": {
+          "optional": true
+        },
+        "@opentelemetry/exporter-trace-otlp-http": {
+          "optional": true
+        },
+        "@opentelemetry/resources": {
+          "optional": true
+        },
+        "@opentelemetry/sdk-metrics": {
+          "optional": true
+        },
+        "@opentelemetry/sdk-trace-base": {
+          "optional": true
+        },
+        "@opentelemetry/sdk-trace-node": {
+          "optional": true
+        },
+        "@smithy/types": {
+          "optional": true
+        },
+        "express": {
+          "optional": true
+        },
+        "openai": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.65.0.tgz",
+      "integrity": "sha512-IEgob78X12rHpUmtcwFsXhZdVGJtwTVP8FiCLZkR6GlYVrl2PcuB+KhCE5BlVC/eQpQnu8WXRtkHZuPar+gCRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/type-utils": "8.65.0",
+        "@typescript-eslint/utils": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.65.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.65.0.tgz",
+      "integrity": "sha512-CZ4nMxWwgu1HEEFNkeaCptra9QCtkmKdgf3sWh1rl1trIhmxLilgTV4cwcbQ4wemnT4sWQN8CaKOmdYx+g2gMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.65.0.tgz",
+      "integrity": "sha512-SxnPhbTsGahizDgbu7oqFH/xVtzIqMd/s+WtnSxNxJZJpLbdT5IPdzg8EZxO3+PoKahXmwJLeNQOpKJb3/bi7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.65.0",
+        "@typescript-eslint/types": "^8.65.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.65.0.tgz",
+      "integrity": "sha512-Esbl8OSYiVxBokYgWPf7VVWg/BE798wXhimnn9ML9Pt5qoDf8bfQlgjlKXR/k98+AcNzlLKYrpCcrcuZ9DZLgg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.65.0.tgz",
+      "integrity": "sha512-j6GzGqCiRdA7Qhur2VVmKZAkBLfnHFQfx4TaJGL9RMveZqCo48jSHHO0DTgizEnGhtWnqmbtCUSrqSkdiY/0Hg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.65.0.tgz",
+      "integrity": "sha512-YjaZ7PRI5qY7ax2L3PbvX0rRyGtipAReCWs0mhhDBHjH/vl0g0BonaGXrKdKpMbIIsMIwDgbk/xzkBTyAltS5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0",
+        "@typescript-eslint/utils": "8.65.0",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.65.0.tgz",
+      "integrity": "sha512-JSSwWNy+H0E/01jJEM+hrX6N0OFDzFzeIhHFSAS01tlVaevpG8cFyYRPhS5yjGOvBUx3sqQHVMjCL1CAZZMxBg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.65.0.tgz",
+      "integrity": "sha512-JboAE2swaYt4tb1fHhHTABE2K+OLy09XfcTbhnk4Pw96f9dd2e9iYsJ28gBggHlo5z5x1rkyWvcPoTuNTd4oGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.65.0",
+        "@typescript-eslint/tsconfig-utils": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.65.0.tgz",
+      "integrity": "sha512-gXiwIHsYreboxeJucHKPvgwl7dXt50mF8s1/c00cP/WoVTyWKFdtfhRWwZiXYFU5H2O8vVoSLNrexFZjYS/SGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.65.0.tgz",
+      "integrity": "sha512-8C71BQkGjiMmXtop7pHVJu1l2NNShFdkCyD6a2ezzs5vU/L3LRtb69EtcteFwz0mYMPzIgOw0n6OV4VBUWZd7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.65.0",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-2.1.9.tgz",
+      "integrity": "sha512-Z2cOr0ksM00MpEfyVE8KXIYPEcBFxdbLSs56L8PO0QQMxt/6bDj45uQfxoc96v05KW3clk7vvgP0qfDit9DmfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^0.2.3",
+        "debug": "^4.3.7",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.12",
+        "magicast": "^0.3.5",
+        "std-env": "^3.8.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "2.1.9",
+        "vitest": "2.1.9"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chalk/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.5.tgz",
+      "integrity": "sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.2",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.6",
+        "@eslint/js": "9.39.5",
+        "@eslint/plugin-kit": "^0.4.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.5",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/eslint/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/eslint/node_modules/brace-expansion": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/eslint/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/eslint/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/eslint/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.0.tgz",
+      "integrity": "sha512-XKJXDsASUOo0LLtFwW5hCcQGH0N4WQc/Rn8/Pvoia+TJFOkkFPvrtW9lZOeeNcxQJspvOIERMwiRLsVFlhHEkA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "debug": "^4.4.3",
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.3.tgz",
+      "integrity": "sha512-/zipXxyO6rGvuNGDiULY9MvEGSkb2gaG4GGH4ygMi0ZZzyMHdUZBmntJmx5x1G2VuPytCwGN4xsJP6cw+sK+vQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/globals": {
+      "version": "17.7.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.7.0.tgz",
+      "integrity": "sha512-Czmyns5dUsq4seFBR/Kdydhmo8y9kC79hiSkPn0YcGtNnYWnrgt0vjrSjx9tspoDGWm2CMarffRuLjM4xUz8xg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.31",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.31.tgz",
+      "integrity": "sha512-zJIHFrl6bq3RDd2YusFNCDlM8qUprxKswyi/OPzPyzKDdyBXDqWx8bZlZ7R+saTdSTatUmb3O7K4SspGPaEOQg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/jose": {
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.4.tgz",
+      "integrity": "sha512-N8acGzVsQy6M/fjFcxtysNc4Q379TcM5dM/qKkNtsHFji88yANnXTr7BLeP75iPnFwBfQzM/jg2BZ9+HZrHCZA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "peer": true
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/mnemonist": {
+      "version": "0.38.3",
+      "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.38.3.tgz",
+      "integrity": "sha512-2K9QYubXx/NAjv4VLq1d1Ly8pWNC5L3BrixtdkyTegXWJIqY+zLNDhhX/A+ZwWt70tB1S8H4BE8FLYEFyNoOBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "obliterator": "^1.6.1"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/obliterator": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-1.6.1.tgz",
+      "integrity": "sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.22",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.22.tgz",
+      "integrity": "sha512-KBDEIpLrvpv16pp3K0Fw+UCoZfopFjjgeB+0tA/aaThfEE74kKDLrgg603YvOWJyg3+WYtyq3xYsQWsIyZlPqQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.16",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
+      "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
+      "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.62.2",
+        "@rollup/rollup-android-arm64": "4.62.2",
+        "@rollup/rollup-darwin-arm64": "4.62.2",
+        "@rollup/rollup-darwin-x64": "4.62.2",
+        "@rollup/rollup-freebsd-arm64": "4.62.2",
+        "@rollup/rollup-freebsd-x64": "4.62.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.2",
+        "@rollup/rollup-linux-arm64-musl": "4.62.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.2",
+        "@rollup/rollup-linux-loong64-musl": "4.62.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-musl": "4.62.2",
+        "@rollup/rollup-openbsd-x64": "4.62.2",
+        "@rollup/rollup-openharmony-arm64": "4.62.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.2",
+        "@rollup/rollup-win32-x64-gnu": "4.62.2",
+        "@rollup/rollup-win32-x64-msvc": "4.62.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
+      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,0 +1,87 @@
+{
+  "name": "strands-dynamodb-storage",
+  "version": "0.1.0",
+  "description": "Community DynamoDB storage backend for the Strands Agents SDK \u2014 one Storage implementation for Session Manager, Memory Manager, and any subsystem, with optional S3 offload for large values and an optional native vector-search hook.",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "!dist/**/*.test.*",
+    "README.md",
+    "LICENSE"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "type-check": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:integ": "vitest run -c vitest.integ.config.ts",
+    "lint": "eslint src test",
+    "lint:fix": "eslint src test --fix",
+    "format": "prettier --write src test",
+    "format:check": "prettier --check src test",
+    "check": "npm run format:check && npm run lint && npm run type-check && npm run test",
+    "prepack": "npm run build"
+  },
+  "keywords": [
+    "strands",
+    "strands-agents",
+    "dynamodb",
+    "storage",
+    "agent",
+    "memory",
+    "session",
+    "aws"
+  ],
+  "author": "Amazon Web Services",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/aws/strands-dynamodb-storage.git"
+  },
+  "bugs": {
+    "url": "https://github.com/aws/strands-dynamodb-storage/issues"
+  },
+  "homepage": "https://github.com/aws/strands-dynamodb-storage#readme",
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "peerDependencies": {
+    "@aws-sdk/client-dynamodb": "^3.1103.0",
+    "@aws-sdk/client-s3": "^3.0.0",
+    "@aws-sdk/lib-dynamodb": "^3.1103.0",
+    "@aws-sdk/util-dynamodb": "^3.996.7",
+    "@strands-agents/sdk": ">=1.10.0"
+  },
+  "peerDependenciesMeta": {
+    "@aws-sdk/client-s3": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@aws-sdk/client-dynamodb": "^3.1104.0",
+    "@aws-sdk/client-s3": "^3.1092.0",
+    "@aws-sdk/client-sts": "^3.1092.0",
+    "@aws-sdk/lib-dynamodb": "^3.1104.0",
+    "@aws-sdk/util-dynamodb": "^3.996.7",
+    "@eslint/js": "^9.0.0",
+    "@strands-agents/sdk": "^1.10.0",
+    "@types/node": "^22.0.0",
+    "@typescript-eslint/eslint-plugin": "^8.0.0",
+    "@typescript-eslint/parser": "^8.0.0",
+    "@vitest/coverage-v8": "^2.1.9",
+    "eslint": "^9.0.0",
+    "globals": "^17.7.0",
+    "prettier": "^3.0.0",
+    "typescript": "^5.5.0",
+    "vitest": "^2.0.0"
+  }
+}

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,7 +1,7 @@
 {
   "name": "strands-dynamodb-storage",
   "version": "0.1.0",
-  "description": "Community DynamoDB storage backend for the Strands Agents SDK \u2014 one Storage implementation for Session Manager, Memory Manager, and any subsystem, with optional S3 offload for large values and an optional native vector-search hook.",
+  "description": "Amazon DynamoDB storage backend for the Strands Agents SDK \u2014 one Storage implementation for Session Manager, Memory Manager, and any subsystem, with optional S3 offload for large values and an optional native vector-search hook.",
   "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/typescript/src/dynamodb-storage.test.ts
+++ b/typescript/src/dynamodb-storage.test.ts
@@ -1,0 +1,666 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'vitest'
+import { SearchVectorsCommand } from '@aws-sdk/client-dynamodb'
+import { PutCommand, GetCommand, DeleteCommand, QueryCommand } from '@aws-sdk/lib-dynamodb'
+import { marshall } from '@aws-sdk/util-dynamodb'
+import { PutObjectCommand, GetObjectCommand, DeleteObjectCommand } from '@aws-sdk/client-s3'
+import { StorageError } from '@strands-agents/sdk'
+import { DynamoDBStorage, type VectorSearchAdapter } from './dynamodb-storage.js'
+import * as pkgIndex from './index.js'
+
+/**
+ * In-memory stand-in for a DynamoDBDocumentClient. Implements only `send`,
+ * backed by a Map keyed by `pk\u0000sk`. Models Put/Get/Delete/Query including
+ * ExclusiveStartKey pagination and ReturnValues=ALL_OLD for delete.
+ */
+class FakeDocumentClient {
+  readonly items = new Map<string, Record<string, any>>()
+  private _k(pk: string, sk: string): string {
+    return `${pk}\u0000${sk}`
+  }
+  /** Captured input of the last SearchVectorsCommand, for request-shape assertions. */
+  lastSearchVectorsInput: any = null
+  async send(command: any): Promise<any> {
+    const input = command.input
+    if (command instanceof SearchVectorsCommand) {
+      this.lastSearchVectorsInput = input
+      const queryVector: number[] = input.SearchVector.map((av: any) => Number(av.N))
+      const pkFilter = input.ExpressionAttributeValues?.[':pk']?.S
+      const scored = [...this.items.values()]
+        .filter((item) => Array.isArray(item.vector))
+        .filter((item) => pkFilter === undefined || item.pk === pkFilter)
+        .map((item) => {
+          const v: number[] = item.vector
+          const dot = v.reduce((acc, x, i) => acc + x * (queryVector[i] ?? 0), 0)
+          const norm =
+            Math.sqrt(v.reduce((a, x) => a + x * x, 0)) * Math.sqrt(queryVector.reduce((a, x) => a + x * x, 0))
+          const cosineDistance = 1 - (norm === 0 ? 0 : dot / norm)
+          const { vector: _v, ...rest } = item
+          return { Item: marshall(rest), Score: cosineDistance }
+        })
+        .sort((a, b) => a.Score - b.Score)
+        .slice(0, input.TopK)
+      return { SearchResults: scored }
+    }
+    if (command instanceof PutCommand) {
+      this.items.set(this._k(input.Item.pk, input.Item.sk), input.Item)
+      return {}
+    }
+    if (command instanceof GetCommand) {
+      return { Item: this.items.get(this._k(input.Key.pk, input.Key.sk)) }
+    }
+    if (command instanceof DeleteCommand) {
+      const key = this._k(input.Key.pk, input.Key.sk)
+      const old = this.items.get(key)
+      this.items.delete(key)
+      return input.ReturnValues === 'ALL_OLD' ? { Attributes: old } : {}
+    }
+    if (command instanceof QueryCommand) {
+      const v = input.ExpressionAttributeValues
+      const pk: string = v[':pk']
+      let matched = [...this.items.values()].filter((item) => item.pk === pk)
+      if (v[':sk'] !== undefined) matched = matched.filter((i) => String(i.sk).startsWith(v[':sk']))
+      if (v[':from'] !== undefined) matched = matched.filter((i) => i.sk >= v[':from'] && i.sk <= v[':to'])
+      // Model the TTL FilterExpression: only present when the caller opted into TTL.
+      if (v[':now'] !== undefined) {
+        const ttlName = input.ExpressionAttributeNames['#ttl']
+        matched = matched.filter((i) => i[ttlName] === undefined || i[ttlName] > v[':now'])
+      }
+      matched.sort((a, b) => (a.sk < b.sk ? -1 : a.sk > b.sk ? 1 : 0))
+      // Model pagination: one item per page so ExclusiveStartKey is exercised.
+      let start = 0
+      if (input.ExclusiveStartKey) {
+        const startSk = input.ExclusiveStartKey.sk
+        start = matched.findIndex((i) => i.sk === startSk) + 1
+      }
+      const page = matched.slice(start, start + 1)
+      const last = page[0]
+      const more = start + 1 < matched.length
+      return {
+        Items: page.map((item) => ({ k: item.k })),
+        LastEvaluatedKey: more && last ? { pk: last.pk, sk: last.sk } : undefined,
+      }
+    }
+    throw new Error(`unexpected command ${command?.constructor?.name}`)
+  }
+}
+
+/** In-memory stand-in for an S3Client covering Put/Get/Delete of object bytes. */
+class FakeS3Client {
+  readonly objects = new Map<string, Uint8Array>()
+  async send(command: any): Promise<any> {
+    const input = command.input
+    if (command instanceof PutObjectCommand) {
+      this.objects.set(input.Key, input.Body)
+      return {}
+    }
+    if (command instanceof GetObjectCommand) {
+      const body = this.objects.get(input.Key)
+      if (!body) throw Object.assign(new Error('NoSuchKey'), { name: 'NoSuchKey' })
+      return { Body: { transformToByteArray: async () => body } }
+    }
+    if (command instanceof DeleteObjectCommand) {
+      this.objects.delete(input.Key)
+      return {}
+    }
+    throw new Error(`unexpected S3 command ${command?.constructor?.name}`)
+  }
+}
+
+function cosine(a: number[], b: number[]): number {
+  let dot = 0
+  let na = 0
+  let nb = 0
+  for (let i = 0; i < a.length; i++) {
+    dot += a[i]! * b[i]!
+    na += a[i]! * a[i]!
+    nb += b[i]! * b[i]!
+  }
+  return dot / (Math.sqrt(na) * Math.sqrt(nb) || 1)
+}
+
+/** Brute-force cosine adapter over the fake client's stored vectors (stands in for SearchVectors). */
+function cosineAdapter(client: FakeDocumentClient): VectorSearchAdapter {
+  return async ({ pk, vector, topK }) => {
+    return [...client.items.values()]
+      .filter((i) => (pk ? i.pk === pk : true) && Array.isArray(i.vector))
+      .map((i) => ({ key: i.k as string, score: cosine(vector, i.vector as number[]), metadata: i.meta }))
+      .sort((a, b) => b.score - a.score)
+      .slice(0, topK)
+  }
+}
+
+function newStorage(opts?: {
+  s3?: boolean
+  prefix?: string
+  vector?: boolean
+  compression?: 'gzip' | 'none'
+  ttlSeconds?: number
+  ttlAttribute?: string
+}) {
+  const client = new FakeDocumentClient()
+  const s3 = new FakeS3Client()
+  const storage = new DynamoDBStorage('test-table', {
+    client: client as any,
+    ...(opts?.prefix ? { prefix: opts.prefix } : {}),
+    ...(opts?.s3 ? { s3Bucket: 'test-bucket', s3Client: s3 as any } : {}),
+    ...(opts?.vector ? { vectorSearch: cosineAdapter(client) } : {}),
+    ...(opts?.compression ? { compression: opts.compression } : {}),
+    ...(opts?.ttlSeconds !== undefined ? { ttlSeconds: opts.ttlSeconds } : {}),
+    ...(opts?.ttlAttribute ? { ttlAttribute: opts.ttlAttribute } : {}),
+  })
+  return { client, s3, storage }
+}
+
+const bytes = (s: string) => new TextEncoder().encode(s)
+const str = (b: Uint8Array | null) => (b ? new TextDecoder().decode(b) : null)
+
+/** High-entropy bytes that gzip cannot meaningfully compress. */
+function randomBytes(n: number): Uint8Array {
+  const a = new Uint8Array(n)
+  for (let i = 0; i < n; i++) a[i] = (Math.random() * 256) | 0
+  return a
+}
+
+describe('DynamoDBStorage — point operations', () => {
+  it('round-trips a value through write and read', async () => {
+    const { storage } = newStorage()
+    await storage.write('sessions/s1/scopes/agent/a1/snapshots/snapshot_latest.json', bytes('hello'))
+    expect(str(await storage.read('sessions/s1/scopes/agent/a1/snapshots/snapshot_latest.json'))).toBe('hello')
+  })
+
+  it('returns null for a missing key', async () => {
+    const { storage } = newStorage()
+    expect(await storage.read('sessions/s1/missing')).toBeNull()
+  })
+
+  it('overwrites an existing value', async () => {
+    const { storage } = newStorage()
+    await storage.write('sessions/s1/a', bytes('v1'))
+    await storage.write('sessions/s1/a', bytes('v2'))
+    expect(str(await storage.read('sessions/s1/a'))).toBe('v2')
+  })
+
+  it('delete removes the value', async () => {
+    const { storage } = newStorage()
+    await storage.write('sessions/s1/a', bytes('x'))
+    await storage.delete('sessions/s1/a')
+    expect(await storage.read('sessions/s1/a')).toBeNull()
+  })
+
+  it('delete is a no-op for a missing key', async () => {
+    const { storage } = newStorage()
+    await expect(storage.delete('sessions/s1/missing')).resolves.toBeUndefined()
+  })
+
+  it('round-trips a single-segment key via the sentinel sort key', async () => {
+    const { storage } = newStorage()
+    await storage.write('singleton', bytes('one'))
+    expect(str(await storage.read('singleton'))).toBe('one')
+    await storage.delete('singleton')
+    expect(await storage.read('singleton')).toBeNull()
+  })
+
+  it('rejects empty and traversal keys', async () => {
+    const { storage } = newStorage()
+    await expect(storage.write('', bytes('x'))).rejects.toThrow(/must not be empty/)
+    await expect(storage.read('sessions/../etc')).rejects.toThrow(/'\.\.'/)
+  })
+})
+
+describe('DynamoDBStorage — listing', () => {
+  it('lists keys under a string prefix, sorted, with pagination', async () => {
+    const { storage } = newStorage()
+    await storage.write('sessions/s1/scopes/agent/a1/immutable_history/snapshot_2.json', bytes('2'))
+    await storage.write('sessions/s1/scopes/agent/a1/immutable_history/snapshot_1.json', bytes('1'))
+    await storage.write('sessions/s1/scopes/agent/a1/immutable_history/snapshot_3.json', bytes('3'))
+    await storage.write('sessions/s1/scopes/agent/a1/snapshots/snapshot_latest.json', bytes('L'))
+    const keys = await storage.list('sessions/s1/scopes/agent/a1/immutable_history/')
+    expect(keys).toEqual([
+      'sessions/s1/scopes/agent/a1/immutable_history/snapshot_1.json',
+      'sessions/s1/scopes/agent/a1/immutable_history/snapshot_2.json',
+      'sessions/s1/scopes/agent/a1/immutable_history/snapshot_3.json',
+    ])
+  })
+
+  it('lists via a structured DynamoDBListQuery naming the partition', async () => {
+    const { storage } = newStorage()
+    await storage.write('sessions/s1/a', bytes('a'))
+    await storage.write('sessions/s1/b', bytes('b'))
+    await storage.write('sessions/s2/c', bytes('c'))
+    expect((await storage.list({ pk: 'sessions/s1' })).sort()).toEqual(['sessions/s1/a', 'sessions/s1/b'])
+  })
+
+  it('supports skBetween range queries', async () => {
+    const { storage } = newStorage()
+    for (const n of ['1', '2', '3', '4']) await storage.write(`sessions/s1/k/${n}`, bytes(n))
+    const keys = await storage.list({ pk: 'sessions/s1', skBetween: ['k/2', 'k/3'] })
+    expect(keys).toEqual(['sessions/s1/k/2', 'sessions/s1/k/3'])
+  })
+
+  it('honors startAfter as an exclusive cursor', async () => {
+    const { storage } = newStorage()
+    for (const n of ['a', 'b', 'c']) await storage.write(`sessions/s1/${n}`, bytes(n))
+    const keys = await storage.list({ pk: 'sessions/s1', startAfter: 'sessions/s1/a' })
+    expect(keys).toEqual(['sessions/s1/b', 'sessions/s1/c'])
+  })
+
+  it('fills a limit with post-cursor keys when startAfter is set (not truncated after the limit)', async () => {
+    const { storage } = newStorage()
+    for (const n of ['1', '2', '3', '4', '5']) await storage.write(`sessions/s1/k/${n}`, bytes(n))
+    const keys = await storage.list({ pk: 'sessions/s1', startAfter: 'sessions/s1/k/1', limit: 2 })
+    expect(keys).toEqual(['sessions/s1/k/2', 'sessions/s1/k/3'])
+  })
+
+  it('rejects a too-broad string prefix that cannot resolve a partition', async () => {
+    const { storage } = newStorage()
+    await expect(storage.list('sessions/')).rejects.toThrow(/too broad/)
+  })
+
+  it('rejects a query specifying both skPrefix and skBetween', async () => {
+    const { storage } = newStorage()
+    await expect(storage.list({ pk: 'x/y', skPrefix: 'a', skBetween: ['a', 'b'] })).rejects.toThrow(/not both/)
+  })
+})
+
+describe('DynamoDBStorage — S3 offload', () => {
+  it('offloads oversized values to S3 and reads them back transparently', async () => {
+    const { storage, s3, client } = newStorage({ s3: true })
+    const big = bytes('Z'.repeat(400_001))
+    await storage.write('sessions/s1/big', big)
+    // Pointer item in DynamoDB, bytes in S3.
+    expect(s3.objects.size).toBe(1)
+    const item = [...client.items.values()][0]!
+    expect(item.s3).toBe(true)
+    expect(item.data).toBeUndefined()
+    expect(str(await storage.read('sessions/s1/big'))).toBe('Z'.repeat(400_001))
+  })
+
+  it('delete cleans up the offloaded S3 object', async () => {
+    const { storage, s3 } = newStorage({ s3: true })
+    await storage.write('sessions/s1/big', bytes('Z'.repeat(400_001)))
+    await storage.delete('sessions/s1/big')
+    expect(s3.objects.size).toBe(0)
+    expect(await storage.read('sessions/s1/big')).toBeNull()
+  })
+
+  it('throws on an oversized value when no S3 bucket is configured', async () => {
+    const { storage } = newStorage()
+    await expect(storage.write('sessions/s1/big', bytes('Z'.repeat(400_001)))).rejects.toThrow(/s3Bucket/)
+  })
+
+  it('stores small values inline (no S3 write)', async () => {
+    const { storage, s3 } = newStorage({ s3: true })
+    await storage.write('sessions/s1/small', bytes('tiny'))
+    expect(s3.objects.size).toBe(0)
+    expect(str(await storage.read('sessions/s1/small'))).toBe('tiny')
+  })
+})
+
+describe('DynamoDBStorage — namespace + prefix', () => {
+  it('applies a constructor prefix transparently to callers', async () => {
+    const { storage } = newStorage({ prefix: 'tenant-x' })
+    await storage.write('sessions/s1/a', bytes('v'))
+    expect(str(await storage.read('sessions/s1/a'))).toBe('v')
+    expect((await storage.list('sessions/s1/')).sort()).toEqual(['sessions/s1/a'])
+  })
+
+  it('namespace() returns a prefixed view that round-trips and lists', async () => {
+    const { storage } = newStorage()
+    const view = storage.namespace!('sessions/s1')
+    await view.write('scopes/agent/a1/x', bytes('v'))
+    expect(str(await view.read('scopes/agent/a1/x'))).toBe('v')
+    // Underlying key includes the namespace prefix.
+    expect(str(await storage.read('sessions/s1/scopes/agent/a1/x'))).toBe('v')
+  })
+})
+
+describe('DynamoDBStorage — vector search', () => {
+  it('stores the embedding inline when a vector is written', async () => {
+    const { storage, client } = newStorage({ vector: true })
+    await storage.write('memory/u1/m1', bytes('likes window seats'), { vector: [1, 0, 0], metadata: { kind: 'pref' } })
+    const item = [...client.items.values()][0]!
+    expect(item.vector).toEqual([1, 0, 0])
+    expect(item.meta).toEqual({ kind: 'pref' })
+    expect(str(await storage.read('memory/u1/m1'))).toBe('likes window seats')
+  })
+
+  it('returns nearest neighbours ordered by similarity, capped at topK', async () => {
+    const { storage } = newStorage({ vector: true })
+    await storage.write('memory/u1/a', bytes('a'), { vector: [1, 0, 0] })
+    await storage.write('memory/u1/b', bytes('b'), { vector: [0.9, 0.1, 0] })
+    await storage.write('memory/u1/c', bytes('c'), { vector: [0, 1, 0] })
+    const results = await storage.search({ vector: [1, 0, 0], topK: 2 })
+    expect(results.map((r) => r.key)).toEqual(['memory/u1/a', 'memory/u1/b'])
+    expect(results[0]!.score).toBeGreaterThanOrEqual(results[1]!.score)
+  })
+
+  it('hydrates stored bytes when includeValues is set', async () => {
+    const { storage } = newStorage({ vector: true })
+    await storage.write('memory/u1/a', bytes('remember me'), { vector: [1, 0, 0] })
+    const results = await storage.search({ vector: [1, 0, 0], topK: 1, includeValues: true })
+    expect(str(results[0]!.data ?? null)).toBe('remember me')
+  })
+
+  it('carries metadata through results', async () => {
+    const { storage } = newStorage({ vector: true })
+    await storage.write('memory/u1/a', bytes('a'), { vector: [1, 0, 0], metadata: { source: 'profile' } })
+    const results = await storage.search({ vector: [1, 0, 0], topK: 1 })
+    expect(results[0]!.metadata).toEqual({ source: 'profile' })
+  })
+
+  it('issues SearchVectors natively when no adapter is configured', async () => {
+    const { storage, client } = newStorage({ prefix: 'tenant/a/' })
+    await storage.write('memories/m1', bytes('a'), { vector: [1, 0, 0], metadata: { source: 'profile' } })
+    await storage.write('memories/m2', bytes('b'), { vector: [0, 1, 0] })
+    const results = await storage.search({ vector: [1, 0, 0], topK: 2, pk: 'tenant/a' })
+    expect(results[0]?.key).toBe('memories/m1') // nearest first, prefix stripped
+    expect(results[0]?.metadata).toEqual({ source: 'profile' })
+    expect(client.lastSearchVectorsInput.SearchConditionExpression).toBe('#pk = :pk')
+    expect(client.lastSearchVectorsInput.ExpressionAttributeValues).toEqual({ ':pk': { S: 'tenant/a' } })
+    expect(client.lastSearchVectorsInput.TopK).toBe(2)
+  })
+
+  it('native path enforces the SearchVectors TopK bounds', async () => {
+    const { storage } = newStorage()
+    await expect(storage.search({ vector: [1, 0, 0], topK: 101 })).rejects.toThrow(/topK/)
+    await expect(storage.search({ vector: [1, 0, 0], topK: 0 })).rejects.toThrow(/topK/)
+  })
+
+  it('native path rejects non-finite query vectors', async () => {
+    const { storage } = newStorage()
+    await expect(storage.search({ vector: [Number.NaN, 0], topK: 1 })).rejects.toThrow(/non-finite/)
+  })
+
+  it('native path over-fetches for filters and post-filters to topK', async () => {
+    const { storage, client } = newStorage({ prefix: 'tenant/a/' })
+    await storage.write('m1', bytes('a'), { vector: [1, 0, 0], metadata: { source: 'web' } })
+    await storage.write('m2', bytes('b'), { vector: [1, 0.1, 0], metadata: { source: 'profile' } })
+    const results = await storage.search({ vector: [1, 0, 0], topK: 1, pk: 'tenant/a', filter: { source: 'profile' } })
+    expect(client.lastSearchVectorsInput.TopK).toBe(10) // topK * over-fetch factor
+    expect(results.map((r) => r.key)).toEqual(['m2'])
+  })
+
+  it('native path drops matches from outside the namespace', async () => {
+    const { storage, client } = newStorage({ prefix: 'tenant/a/' })
+    // Seed a foreign-tenant item directly into the fake table.
+    client.items.set('tenant/b\u0000m1', { pk: 'tenant/b', sk: 'm1', vector: [1, 0, 0] })
+    const results = await storage.search({ vector: [1, 0, 0], topK: 1 })
+    expect(results).toEqual([])
+  })
+})
+
+describe('DynamoDBStorage — compression', () => {
+  it('round-trips a compressible value and stores it gzipped inline', async () => {
+    const { storage, client } = newStorage({ compression: 'gzip' })
+    const original = 'A'.repeat(5000)
+    await storage.write('sessions/s1/big', bytes(original))
+    const item = [...client.items.values()][0]!
+    expect(item.z).toBe(true)
+    expect((item.data as Uint8Array).byteLength).toBeLessThan(5000)
+    expect(str(await storage.read('sessions/s1/big'))).toBe(original)
+  })
+
+  it('keeps a large-but-compressible value inline instead of offloading to S3', async () => {
+    // 800 KB of repeated bytes: over the 380 KB inline limit raw, but gzips far under it.
+    const { storage, s3, client } = newStorage({ compression: 'gzip', s3: true })
+    const original = 'A'.repeat(800_000)
+    await storage.write('sessions/s1/big', bytes(original))
+    expect(s3.objects.size).toBe(0) // no offload — the cost win
+    const item = [...client.items.values()][0]!
+    expect(item.z).toBe(true)
+    expect(item.s3).toBeUndefined()
+    expect(str(await storage.read('sessions/s1/big'))).toBe(original)
+  })
+
+  it('stores uncompressed when compression does not shrink the value', async () => {
+    const { storage, client } = newStorage({ compression: 'gzip' })
+    await storage.write('sessions/s1/tiny', bytes('hi')) // gzip overhead exceeds 2 bytes
+    const item = [...client.items.values()][0]!
+    expect(item.z).toBeUndefined()
+    expect(str(await storage.read('sessions/s1/tiny'))).toBe('hi')
+  })
+
+  it('reads a compressed item even when the reader has compression disabled', async () => {
+    const { client } = newStorage({ compression: 'gzip' })
+    const writer = new DynamoDBStorage('test-table', { client: client as any, compression: 'gzip' })
+    await writer.write('sessions/s1/a', bytes('A'.repeat(2000)))
+    const reader = new DynamoDBStorage('test-table', { client: client as any }) // compression off
+    expect(str(await reader.read('sessions/s1/a'))).toBe('A'.repeat(2000))
+  })
+
+  it('offloads to S3 when even the compressed value exceeds the item limit', async () => {
+    // High-entropy payload: gzip cannot shrink it below the threshold, so it offloads.
+    const { storage, s3, client } = newStorage({ compression: 'gzip', s3: true })
+    const original = randomBytes(400_001)
+    await storage.write('sessions/s1/big', original)
+    expect(s3.objects.size).toBe(1)
+    const item = [...client.items.values()][0]!
+    expect(item.s3).toBe(true)
+    expect(item.data).toBeUndefined()
+    expect(await storage.read('sessions/s1/big')).toEqual(original)
+  })
+})
+
+describe('DynamoDBStorage — TTL', () => {
+  it('stamps an epoch-seconds expiry when ttlSeconds is configured', async () => {
+    const { storage, client } = newStorage({ ttlSeconds: 3600 })
+    const before = Math.floor(Date.now() / 1000)
+    await storage.write('sessions/s1/a', bytes('v'))
+    const item = [...client.items.values()][0]!
+    expect(typeof item.expireAt).toBe('number')
+    expect(item.expireAt).toBeGreaterThanOrEqual(before + 3600)
+    expect(item.expireAt).toBeLessThanOrEqual(Math.floor(Date.now() / 1000) + 3600 + 2)
+  })
+
+  it('writes no TTL attribute when ttlSeconds is not configured', async () => {
+    const { storage, client } = newStorage()
+    await storage.write('sessions/s1/a', bytes('v'))
+    const item = [...client.items.values()][0]!
+    expect(item.expireAt).toBeUndefined()
+  })
+
+  it('lets a per-write ttlSeconds override the instance default', async () => {
+    const { storage, client } = newStorage({ ttlSeconds: 60 })
+    const before = Math.floor(Date.now() / 1000)
+    await storage.write('sessions/s1/a', bytes('v'), { ttlSeconds: 7200 })
+    const item = [...client.items.values()][0]!
+    expect(item.expireAt).toBeGreaterThanOrEqual(before + 7200)
+  })
+
+  it('honors a custom ttlAttribute name', async () => {
+    const { storage, client } = newStorage({ ttlSeconds: 60, ttlAttribute: 'ttl' })
+    await storage.write('sessions/s1/a', bytes('v'))
+    const item = [...client.items.values()][0]!
+    expect(typeof item.ttl).toBe('number')
+    expect(item.expireAt).toBeUndefined()
+  })
+
+  it('stamps TTL on the pointer item of an S3-offloaded value', async () => {
+    const { storage, client } = newStorage({ ttlSeconds: 60, s3: true })
+    await storage.write('sessions/s1/big', bytes('Z'.repeat(400_001)))
+    const item = [...client.items.values()][0]!
+    expect(item.s3).toBe(true)
+    expect(typeof item.expireAt).toBe('number')
+  })
+})
+
+describe('DynamoDBStorage — TTL read filtering (opt-in)', () => {
+  it('read returns null for an item whose expiry has passed', async () => {
+    const { storage } = newStorage({ ttlSeconds: 3600 })
+    await storage.write('sessions/s1/a', bytes('v'), { ttlSeconds: -1 }) // already expired
+    expect(await storage.read('sessions/s1/a')).toBeNull()
+  })
+
+  it('list omits expired items and keeps live ones', async () => {
+    const { storage } = newStorage({ ttlSeconds: 3600 })
+    await storage.write('sessions/s1/live', bytes('L'))
+    await storage.write('sessions/s1/dead', bytes('D'), { ttlSeconds: -1 })
+    expect(await storage.list({ pk: 'sessions/s1' })).toEqual(['sessions/s1/live'])
+  })
+
+  it('does NOT filter when TTL is not enabled (opt-in): a non-TTL reader returns the item', async () => {
+    // Written by a TTL-enabled instance with a past expiry...
+    const { client } = newStorage({ ttlSeconds: 3600 })
+    const writer = new DynamoDBStorage('test-table', { client: client as any, ttlSeconds: 3600 })
+    await writer.write('sessions/s1/a', bytes('v'), { ttlSeconds: -1 })
+    // ...but a reader that did not opt into TTL injects no filter and returns it.
+    const reader = new DynamoDBStorage('test-table', { client: client as any })
+    expect(str(await reader.read('sessions/s1/a'))).toBe('v')
+    expect(await reader.list({ pk: 'sessions/s1' })).toEqual(['sessions/s1/a'])
+  })
+
+  it('does not stamp an expiry when TTL is not enabled, even with a per-write ttlSeconds', async () => {
+    const { storage, client } = newStorage() // TTL not enabled
+    await storage.write('sessions/s1/a', bytes('v'), { ttlSeconds: 60 })
+    const item = [...client.items.values()][0]!
+    expect(item.expireAt).toBeUndefined()
+  })
+})
+
+describe('DynamoDBStorage — namespace inherits compression + TTL', () => {
+  it('applies compression and TTL to items written through a namespaced view', async () => {
+    const { storage, client } = newStorage({ compression: 'gzip', ttlSeconds: 3600 })
+    const view = storage.namespace('sessions/s1')
+    await view.write('scopes/agent/a1/x', bytes('A'.repeat(2000)))
+    const item = [...client.items.values()][0]!
+    expect(item.z).toBe(true)
+    expect(typeof item.expireAt).toBe('number')
+    expect(item.k).toBe('sessions/s1/scopes/agent/a1/x')
+    expect(str(await view.read('scopes/agent/a1/x'))).toBe('A'.repeat(2000))
+  })
+})
+
+describe('DynamoDBStorage — construction + error wrapping', () => {
+  // A Document client whose every send rejects, to drive the catch/wrap branches.
+  const boom = {
+    send: async () => {
+      throw new Error('boom')
+    },
+  } as any
+
+  it('rejects being configured with both client and region', () => {
+    expect(() => new DynamoDBStorage('t', { client: boom, region: 'us-east-1' })).toThrow(/both client and region/)
+  })
+
+  it('wraps a write failure as StorageError preserving the cause', async () => {
+    const s = new DynamoDBStorage('t', { client: boom })
+    await expect(s.write('sessions/s1/a', bytes('x'))).rejects.toBeInstanceOf(StorageError)
+    const err = await s.write('sessions/s1/a', bytes('x')).catch((e) => e)
+    expect(err).toBeInstanceOf(StorageError)
+    expect((err as Error).cause).toBeInstanceOf(Error)
+  })
+
+  it('wraps read, delete, and list failures as StorageError', async () => {
+    const s = new DynamoDBStorage('t', { client: boom })
+    await expect(s.read('sessions/s1/a')).rejects.toBeInstanceOf(StorageError)
+    await expect(s.delete('sessions/s1/a')).rejects.toBeInstanceOf(StorageError)
+    await expect(s.list({ pk: 'sessions/s1' })).rejects.toBeInstanceOf(StorageError)
+  })
+
+  it('wraps a vectorSearch adapter failure as StorageError', async () => {
+    const s = new DynamoDBStorage('t', {
+      client: boom,
+      vectorSearch: async () => {
+        throw new Error('adapter boom')
+      },
+    })
+    await expect(s.search({ vector: [1, 0, 0], topK: 1 })).rejects.toBeInstanceOf(StorageError)
+  })
+
+  it('rejects a list prefix containing a ".." segment', async () => {
+    const s = new DynamoDBStorage('t', { client: boom })
+    await expect(s.list('sessions/../etc')).rejects.toThrow(/'\.\.'/)
+  })
+
+  it('namespace() on a region-configured instance returns a composable view', () => {
+    const s = new DynamoDBStorage('t', { region: 'us-east-1' })
+    const view = s.namespace('sessions/s1')
+    expect(view).toBeInstanceOf(DynamoDBStorage)
+    expect(view.namespace('scopes/agent/a1')).toBeInstanceOf(DynamoDBStorage)
+  })
+
+  it('is re-exported from the package index barrel', () => {
+    expect(pkgIndex.DynamoDBStorage).toBe(DynamoDBStorage)
+  })
+})
+
+describe('DynamoDBStorage — namespace isolation', () => {
+  /** Two namespaced instances over one shared table. */
+  function twoTenants(vectorSearch?: VectorSearchAdapter) {
+    const client = new FakeDocumentClient()
+    const opts = (prefix: string) => ({
+      client: client as any,
+      prefix,
+      ...(vectorSearch ? { vectorSearch } : {}),
+    })
+    return {
+      client,
+      a: new DynamoDBStorage('test-table', opts('tenant-a')),
+      b: new DynamoDBStorage('test-table', opts('tenant-b')),
+    }
+  }
+
+  it('rejects a structured query naming another namespace partition', async () => {
+    const { a, b } = twoTenants()
+    await a.write('sessions/s1/secret', bytes('a-data'))
+    await expect(b.list({ pk: 'tenant-a/sessions' })).rejects.toThrow(StorageError)
+    await expect(b.list({ pk: 'tenant-a/sessions' })).rejects.toThrow(/outside this storage namespace/)
+    // the owning instance can still query its own partition
+    expect(await a.list({ pk: 'tenant-a/sessions' })).toEqual(['sessions/s1/secret'])
+  })
+
+  it('rejects a partition that only shares a string prefix with the namespace', async () => {
+    const { b } = twoTenants()
+    await expect(b.list({ pk: 'tenant' })).rejects.toThrow(/outside this storage namespace/)
+  })
+
+  it('leaves an unprefixed instance free to name any partition', async () => {
+    const { storage } = newStorage()
+    await storage.write('sessions/s1/a', bytes('1'))
+    expect(await storage.list({ pk: 'sessions/s1' })).toEqual(['sessions/s1/a'])
+  })
+
+  it('allows a namespaced view to query the ancestor partition it lives in', async () => {
+    const { storage } = newStorage()
+    const view = storage.namespace!('sessions/s1')
+    await view.write('scopes/agent/a1/x', bytes('v'))
+    await storage.write('sessions/s2/other', bytes('sibling'))
+    expect(await view.list({ pk: 'sessions/s1' })).toEqual(['scopes/agent/a1/x'])
+  })
+
+  it('rejects a search pk outside the namespace before calling the adapter', async () => {
+    const adapter: VectorSearchAdapter = async () => {
+      throw new Error('adapter must not be reached for an out-of-scope pk')
+    }
+    const { b } = twoTenants(adapter)
+    await expect(b.search!({ vector: [1, 0], topK: 1, pk: 'tenant-a/sessions' })).rejects.toThrow(
+      /outside this storage namespace/
+    )
+  })
+
+  it('drops search matches that fall outside the namespace', async () => {
+    const leaky: VectorSearchAdapter = async () => [
+      { key: 'tenant-a/sessions/s1/secret', score: 0.99 },
+      { key: 'tenant-b/sessions/s1/mine', score: 0.98 },
+    ]
+    const { b } = twoTenants(leaky)
+    const results = await b.search!({ vector: [1, 0], topK: 2 })
+    expect(results.map((r) => r.key)).toEqual(['sessions/s1/mine'])
+  })
+
+  it('drops listed rows whose stored key belongs to another namespace', async () => {
+    const { client, b } = twoTenants()
+    await b.write('sessions/s1/mine', bytes('ok'))
+    // Plant a row inside our partition whose stored key attribute points elsewhere.
+    client.items.set('tenant-b/sessions\u0000s1/planted', {
+      pk: 'tenant-b/sessions',
+      sk: 's1/planted',
+      k: 'tenant-a/sessions/s1/secret',
+      data: bytes('x'),
+    })
+    expect(await b.list({ pk: 'tenant-b/sessions' })).toEqual(['sessions/s1/mine'])
+  })
+})

--- a/typescript/src/dynamodb-storage.ts
+++ b/typescript/src/dynamodb-storage.ts
@@ -452,7 +452,9 @@ export class DynamoDBStorage implements Storage<string | DynamoDBListQuery> {
       throw new StorageError(`topK must be between 1 and ${MAX_TOP_K} (SearchVectors TopK limit); got ${query.topK}`)
     }
     if (!query.vector.every((v) => Number.isFinite(v))) {
-      throw new StorageError('Query vector contains non-finite values (NaN/Infinity); the DynamoDB N type rejects them.')
+      throw new StorageError(
+        'Query vector contains non-finite values (NaN/Infinity); the DynamoDB N type rejects them.'
+      )
     }
     const topK = query.filter !== undefined ? Math.min(query.topK * FILTER_OVERFETCH, MAX_TOP_K) : query.topK
 

--- a/typescript/src/dynamodb-storage.ts
+++ b/typescript/src/dynamodb-storage.ts
@@ -1,0 +1,685 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { StorageError } from '@strands-agents/sdk'
+import type { Storage } from '@strands-agents/sdk/storage'
+
+import { gunzip, gzip } from 'node:zlib'
+import { promisify } from 'node:util'
+
+import { normalizeKey, normalizePrefix } from './keys.js'
+
+const gzipAsync = promisify(gzip)
+const gunzipAsync = promisify(gunzip)
+
+/**
+ * Structured list query for the DynamoDB backend.
+ *
+ * The {@link Storage} `list` argument is generic precisely so backends like
+ * DynamoDB and RDS can accept a richer query than a plain string prefix. A
+ * `DynamoDBListQuery` names the partition (`pk`) directly, so listing is a native
+ * `Query` against one partition instead of an inferred prefix scan.
+ *
+ * SDK-internal callers still pass a plain string prefix; see {@link DynamoDBStorage.list}.
+ */
+export interface DynamoDBListQuery {
+  /** Partition key to query. */
+  pk: string
+  /** Optional sort-key prefix (`begins_with`). Mutually exclusive with `skBetween`. */
+  skPrefix?: string
+  /** Optional inclusive sort-key range `[from, to]`. Mutually exclusive with `skPrefix`. */
+  skBetween?: [string, string]
+  /** Max number of keys to return. */
+  limit?: number
+  /** Exclusive start cursor (a key returned by a prior call). */
+  startAfter?: string
+}
+
+/**
+ * Vector similarity query for backends that support native ANN search (e.g. the
+ * DynamoDB vector index). Optional on {@link Storage}; consumers feature-detect
+ * `if (storage.search)` and fall back to client-side KNN when absent.
+ */
+export interface SearchQuery {
+  /** Query embedding. */
+  vector: number[]
+  /** Number of nearest neighbours to return. */
+  topK: number
+  /** Optional partition/scope to search within. */
+  pk?: string
+  /** Optional metadata pre-filter (equality). */
+  filter?: Record<string, string | number | boolean>
+  /** When true, hydrate each result's stored bytes via `read`. Default false. */
+  includeValues?: boolean
+}
+
+/** A single similarity match. */
+export interface SearchResult {
+  /** Storage key of the matched item (with any constructor prefix stripped). */
+  key: string
+  /** Similarity score (backend-defined; higher is nearer for cosine/dot). */
+  score: number
+  /** Stored bytes, present only when `includeValues` was requested. */
+  data?: Uint8Array
+  /** Metadata stored alongside the item, when available. */
+  metadata?: Record<string, unknown>
+}
+
+/**
+ * Optional override for the vector-search call. By default {@link DynamoDBStorage.search}
+ * issues DynamoDB `SearchVectors` natively (requires `@aws-sdk/client-dynamodb` >= 3.1103.0);
+ * supply an adapter to replace the call (e.g. for testing or custom routing).
+ */
+export type VectorSearchAdapter = (params: {
+  tableName: string
+  indexName: string
+  vectorAttribute: string
+  pk?: string
+  vector: number[]
+  topK: number
+  filter?: Record<string, string | number | boolean>
+}) => Promise<Array<{ key: string; score: number; metadata?: Record<string, unknown> }>>
+
+/** Configuration for {@link DynamoDBStorage}. */
+export interface DynamoDBStorageConfig {
+  /** AWS region override. Ignored when `client` is supplied. */
+  region?: string
+  /** Pre-configured DynamoDB Document client. Cannot be combined with `region`. */
+  client?: import('@aws-sdk/lib-dynamodb').DynamoDBDocumentClient
+  /** Optional key prefix prepended to every key (a namespace within the table). */
+  prefix?: string
+  /**
+   * Optional S3 bucket for offloading values larger than the DynamoDB item limit.
+   * When unset, oversized values throw rather than silently truncating.
+   */
+  s3Bucket?: string
+  /** Optional key prefix for offloaded S3 objects. */
+  s3Prefix?: string
+  /** Pre-configured S3 client for offload. Ignored unless `s3Bucket` is set. */
+  s3Client?: import('@aws-sdk/client-s3').S3Client
+  /**
+   * Optional transparent gzip compression of stored values. Applied before the
+   * S3-offload size check, so compressible values are more likely to stay inline in
+   * DynamoDB — reducing item size, storage cost, and S3 spillover. Each item records
+   * whether it was compressed, so reads are correct regardless of this setting, and
+   * values that do not shrink are stored uncompressed. Default `'none'`.
+   */
+  compression?: 'gzip' | 'none'
+  /**
+   * Optional time-to-live in seconds. Setting it opts in to TTL: each written item
+   * carries an epoch-seconds expiry attribute (see `ttlAttribute`) so DynamoDB native
+   * TTL reaps it, and `read`/`list` filter out items whose expiry has already passed —
+   * covering the up-to-~48h lag before DynamoDB physically deletes them. A per-write
+   * `ttlSeconds` tunes the duration for that write.
+   *
+   * Physical cleanup requires TTL enabled on that attribute at the table level. When
+   * combined with S3 offload, expiry removes only the DynamoDB pointer item — configure
+   * an S3 lifecycle rule to reclaim offloaded objects.
+   */
+  ttlSeconds?: number
+  /** Item attribute holding the epoch-seconds TTL. Default `'expireAt'`. */
+  ttlAttribute?: string
+  /** Name of the vector index on the table (for `search`). Default `'vector_index'`. */
+  indexName?: string
+  /** Item attribute holding the embedding vector. Default `'vector'`. */
+  vectorAttribute?: string
+  /** Adapter that performs the native vector search. Required to use `search()` until GA. */
+  vectorSearch?: VectorSearchAdapter
+}
+
+/** Attribute names for the single-table layout. */
+const PK = 'pk'
+const SK = 'sk'
+const KEY_ATTR = 'k'
+const DATA_ATTR = 'data'
+const S3_ATTR = 's3'
+const META_ATTR = 'meta'
+const Z_ATTR = 'z'
+/** Service maximum for SearchVectors TopK ("must be between 1 and 100 inclusive"). */
+const MAX_TOP_K = 100
+/** Over-fetch factor for client-side metadata filtering, capped at MAX_TOP_K. */
+const FILTER_OVERFETCH = 10
+
+/**
+ * DynamoDB {@link Storage} backend (single-table design).
+ *
+ * Persists each key as one item: the `/`-separated key is split into a partition
+ * key (leading scope) and a sort key (remainder), with the raw bytes in a binary
+ * `data` attribute. Point operations are single-item `PutItem`/`GetItem`/`DeleteItem`.
+ * Listing is a native `Query` — a string prefix is resolved to a partition plus a
+ * `begins_with` sort condition, while a {@link DynamoDBListQuery} names the partition
+ * directly (the intended DDB extension point of the generic `Storage` interface).
+ *
+ * Values above the 400 KB item limit are offloaded to S3 when an `s3Bucket` is
+ * configured; a small pointer item stays in DynamoDB. The AWS SDK modules are
+ * lazy-imported and declared as peer dependencies (S3 optional), so consumers that
+ * never construct a `DynamoDBStorage` are not forced to install them.
+ *
+ * Optional transparent gzip `compression` shrinks stored values (and keeps more of
+ * them inline, out of S3), and an optional `ttlSeconds` stamps a DynamoDB-native TTL
+ * attribute so ephemeral session/memory data self-expires.
+ *
+ * @example
+ * ```typescript
+ * import { Agent, SessionManager } from '@strands-agents/sdk'
+ * import { DynamoDBStorage } from 'strands-dynamodb-storage'
+ *
+ * const storage = new DynamoDBStorage('agent-data', { region: 'us-east-1' })
+ * const agent = new Agent({ sessionManager: new SessionManager({ storage }) })
+ * ```
+ */
+export class DynamoDBStorage implements Storage<string | DynamoDBListQuery> {
+  /** Leave margin below DynamoDB's 400 KB item limit for keys and metadata. */
+  private static readonly OFFLOAD_THRESHOLD_BYTES = 380_000
+
+  private readonly _tableName: string
+  private readonly _prefix: string
+  private readonly _region: string | undefined
+  private readonly _s3Bucket: string | undefined
+  private readonly _s3Prefix: string
+  private readonly _indexName: string
+  private readonly _vectorAttribute: string
+  private readonly _vectorSearch: VectorSearchAdapter | undefined
+  private readonly _compress: boolean
+  private readonly _ttlSeconds: number | undefined
+  private readonly _ttlEnabled: boolean
+  private readonly _ttlAttribute: string
+  private _client: import('@aws-sdk/lib-dynamodb').DynamoDBDocumentClient | undefined
+  private _s3Client: import('@aws-sdk/client-s3').S3Client | undefined
+
+  /**
+   * @param tableName - Target DynamoDB table (partition key `pk` string, sort key `sk` string)
+   * @param config - Optional region/client, key prefix, and S3-offload settings
+   * @throws {@link StorageError} if both `region` and `client` are provided
+   */
+  constructor(tableName: string, config?: DynamoDBStorageConfig) {
+    if (config?.client && config.region) {
+      throw new StorageError('Cannot specify both client and region. Configure the region on the client instead.')
+    }
+    this._tableName = tableName
+    this._prefix = config?.prefix ? config.prefix.split('/').filter(Boolean).join('/') + '/' : ''
+    this._region = config?.region
+    this._client = config?.client
+    this._s3Bucket = config?.s3Bucket
+    this._s3Prefix = config?.s3Prefix ? config.s3Prefix.split('/').filter(Boolean).join('/') + '/' : ''
+    this._s3Client = config?.s3Client
+    this._indexName = config?.indexName ?? 'vector_index'
+    this._vectorAttribute = config?.vectorAttribute ?? 'vector'
+    this._vectorSearch = config?.vectorSearch
+    this._compress = config?.compression === 'gzip'
+    this._ttlSeconds = config?.ttlSeconds
+    this._ttlEnabled = config?.ttlSeconds !== undefined
+    this._ttlAttribute = config?.ttlAttribute ?? 'expireAt'
+  }
+
+  /**
+   * Stores `data` under `key`, overwriting any existing value. Values above the
+   * item-size limit are offloaded to S3 when an `s3Bucket` is configured. An optional
+   * `vector` (kept inline for the native index) and `metadata` enable `search`.
+   *
+   * @throws {@link StorageError} if the key is invalid, the value is oversized with
+   *   no S3 bucket configured, or the write fails
+   */
+  async write(
+    key: string,
+    data: Uint8Array,
+    options?: { vector?: number[]; metadata?: Record<string, string | number | boolean>; ttlSeconds?: number }
+  ): Promise<void> {
+    const normalized = normalizeKey(key)
+    const full = `${this._prefix}${normalized}`
+    const { pk, sk } = this._split(full)
+    const extra: Record<string, unknown> = {}
+    // The embedding stays inline in DynamoDB even when the payload is offloaded,
+    // because the native vector index can only index an on-item attribute.
+    if (options?.vector) extra[this._vectorAttribute] = options.vector
+    if (options?.metadata) extra[META_ATTR] = options.metadata
+    const ttlSeconds = options?.ttlSeconds ?? this._ttlSeconds
+    if (this._ttlEnabled && ttlSeconds !== undefined) {
+      extra[this._ttlAttribute] = Math.floor(Date.now() / 1000) + ttlSeconds
+    }
+    // Compress before the size check so compressible values can stay inline (and out
+    // of S3). Keep the compressed form only when it actually shrinks, and record the
+    // choice per item so reads decompress correctly regardless of the current setting.
+    let payload: Uint8Array = data
+    if (this._compress) {
+      const gz = await gzipAsync(data)
+      if (gz.byteLength < data.byteLength) {
+        payload = gz
+        extra[Z_ATTR] = true
+      }
+    }
+    try {
+      if (payload.byteLength > DynamoDBStorage.OFFLOAD_THRESHOLD_BYTES) {
+        if (!this._s3Bucket) {
+          throw new StorageError(
+            `Value for '${normalized}' is ${payload.byteLength} bytes, above the ${DynamoDBStorage.OFFLOAD_THRESHOLD_BYTES}-byte limit; configure s3Bucket to offload large values`
+          )
+        }
+        await this._s3Put(full, payload)
+        await this._put({ [PK]: pk, [SK]: sk, [KEY_ATTR]: full, [S3_ATTR]: true, ...extra })
+      } else {
+        await this._put({ [PK]: pk, [SK]: sk, [KEY_ATTR]: full, [DATA_ATTR]: payload, ...extra })
+      }
+    } catch (error: unknown) {
+      if (error instanceof StorageError) throw error
+      throw new StorageError(`Failed to write '${normalized}' to DynamoDB table '${this._tableName}'`, { cause: error })
+    }
+  }
+
+  /**
+   * Retrieves the bytes previously stored under `key`.
+   *
+   * @returns The stored bytes, or `null` if no value exists for `key`
+   * @throws {@link StorageError} if the key is invalid or the read fails
+   */
+  async read(key: string): Promise<Uint8Array | null> {
+    const normalized = normalizeKey(key)
+    const full = `${this._prefix}${normalized}`
+    const { pk, sk } = this._split(full)
+    try {
+      const { GetCommand } = await import('@aws-sdk/lib-dynamodb')
+      const client = await this._getClient()
+      const response = await client.send(new GetCommand({ TableName: this._tableName, Key: { [PK]: pk, [SK]: sk } }))
+      const item = response.Item
+      if (!item) return null
+      // Hide items whose TTL has passed but DynamoDB has not yet physically reaped
+      // (native TTL deletion lags up to ~48h). Only when TTL is opted into. Runs
+      // before any S3 fetch.
+      if (this._ttlEnabled && this._isExpired(item)) return null
+      const compressed = item[Z_ATTR] === true
+      let raw: Uint8Array | null
+      if (item[S3_ATTR]) {
+        raw = await this._s3Get(full)
+      } else {
+        const stored = item[DATA_ATTR] as Uint8Array | undefined
+        raw = stored ? new Uint8Array(stored) : null
+      }
+      if (raw === null) return null
+      return compressed ? new Uint8Array(await gunzipAsync(raw)) : raw
+    } catch (error: unknown) {
+      if (error instanceof StorageError) throw error
+      throw new StorageError(`Failed to read '${normalized}' from DynamoDB table '${this._tableName}'`, {
+        cause: error,
+      })
+    }
+  }
+
+  /**
+   * Deletes the value stored under `key`, including any offloaded S3 object.
+   * A no-op if the key does not exist.
+   *
+   * @throws {@link StorageError} if the key is invalid or the delete fails
+   */
+  async delete(key: string): Promise<void> {
+    const normalized = normalizeKey(key)
+    const full = `${this._prefix}${normalized}`
+    const { pk, sk } = this._split(full)
+    try {
+      const { DeleteCommand } = await import('@aws-sdk/lib-dynamodb')
+      const client = await this._getClient()
+      // ReturnValues=ALL_OLD lets us clean up an offloaded S3 object without a prior read.
+      const response = await client.send(
+        new DeleteCommand({ TableName: this._tableName, Key: { [PK]: pk, [SK]: sk }, ReturnValues: 'ALL_OLD' })
+      )
+      if (response.Attributes?.[S3_ATTR]) await this._s3Delete(full)
+    } catch (error: unknown) {
+      if (error instanceof StorageError) throw error
+      throw new StorageError(`Failed to delete '${normalized}' from DynamoDB table '${this._tableName}'`, {
+        cause: error,
+      })
+    }
+  }
+
+  /**
+   * Lists keys, sorted ascending.
+   *
+   * Accepts either:
+   * - a **string prefix** (SDK-internal path): resolved to a partition plus a
+   *   `begins_with` sort condition. The prefix must include at least the scope and
+   *   its identifier (e.g. `sessions/<id>/...`) so a partition can be determined.
+   * - a **{@link DynamoDBListQuery}**: a native query that names the partition directly.
+   *
+   * @returns The matching full keys, sorted ascending
+   * @throws {@link StorageError} if the query is invalid or the list fails
+   */
+  async list(query: string | DynamoDBListQuery): Promise<string[]> {
+    try {
+      if (typeof query === 'string') {
+        return await this._listByPrefix(query)
+      }
+      return await this._listByQuery(query)
+    } catch (error: unknown) {
+      if (error instanceof StorageError) throw error
+      const label = typeof query === 'string' ? `'${query}'` : `pk='${query.pk}'`
+      throw new StorageError(`Failed to list DynamoDB table '${this._tableName}' under ${label}`, { cause: error })
+    }
+  }
+
+  /**
+   * Returns a view of this storage with all keys prefixed by `prefix`, without
+   * mutating the original.
+   *
+   * Unlike the SDK's generic string-only namespace helper, this returns a real
+   * `DynamoDBStorage` sharing the same client and settings, so structured
+   * {@link DynamoDBListQuery} listing and {@link DynamoDBStorage.search} survive
+   * namespacing. Nested calls compose.
+   */
+  namespace(prefix: string): DynamoDBStorage {
+    const sub = normalizePrefix(prefix)
+    const config: DynamoDBStorageConfig = {
+      prefix: `${this._prefix}${sub}`,
+      indexName: this._indexName,
+      vectorAttribute: this._vectorAttribute,
+    }
+    if (this._client) config.client = this._client
+    else if (this._region !== undefined) config.region = this._region
+    if (this._s3Bucket !== undefined) config.s3Bucket = this._s3Bucket
+    if (this._s3Prefix) config.s3Prefix = this._s3Prefix
+    if (this._s3Client) config.s3Client = this._s3Client
+    if (this._vectorSearch) config.vectorSearch = this._vectorSearch
+    if (this._compress) config.compression = 'gzip'
+    if (this._ttlSeconds !== undefined) config.ttlSeconds = this._ttlSeconds
+    config.ttlAttribute = this._ttlAttribute
+    return new DynamoDBStorage(this._tableName, config)
+  }
+
+  /**
+   * Nearest-neighbour vector search over items written with a `vector`.
+   *
+   * Optional part of the {@link Storage} contract — consumers feature-detect
+   * `if (storage.search)` and fall back to client-side KNN when absent. On DynamoDB
+   * this runs against the native vector index, so scoring happens in the database.
+   *
+   * Issues DynamoDB `SearchVectors` natively; a `vectorSearch` adapter, when
+   * configured, overrides the call. The score is the raw index `Score` and its
+   * direction depends on the index's distance function: for COSINE and EUCLIDEAN
+   * lower is closer; for DOT_PRODUCT higher is more similar. Results arrive in
+   * the service's most-similar-first order. Like a global secondary index, the
+   * vector index is eventually consistent.
+   *
+   * @throws {@link StorageError} if the search fails or `topK` is out of range
+   */
+  async search(query: SearchQuery): Promise<SearchResult[]> {
+    if (query.pk !== undefined) this._assertPkInScope(query.pk)
+    try {
+      const matches = this._vectorSearch
+        ? await this._vectorSearch({
+            tableName: this._tableName,
+            indexName: this._indexName,
+            vectorAttribute: this._vectorAttribute,
+            vector: query.vector,
+            topK: query.topK,
+            ...(query.pk !== undefined && { pk: query.pk }),
+            ...(query.filter !== undefined && { filter: query.filter }),
+          })
+        : await this._nativeVectorSearch(query)
+      const results: SearchResult[] = []
+      for (const match of matches) {
+        // Defence in depth: pk is optional, so the index may return matches from
+        // outside this namespace. Drop them rather than de-prefixing blindly — a
+        // foreign key would otherwise be handed back looking like one of ours.
+        const key = this._stripPrefix(match.key)
+        if (key === null) continue
+        const result: SearchResult = { key, score: match.score }
+        if (match.metadata !== undefined) result.metadata = match.metadata
+        if (query.includeValues) {
+          const data = await this.read(key)
+          if (data) result.data = data
+        }
+        results.push(result)
+      }
+      return results
+    } catch (error: unknown) {
+      if (error instanceof StorageError) throw error
+      throw new StorageError(`Failed to search DynamoDB table '${this._tableName}'`, { cause: error })
+    }
+  }
+
+  /**
+   * Issues DynamoDB `SearchVectors` directly (GA path, no adapter).
+   *
+   * `query.pk` pins `SearchConditionExpression` to one partition (already
+   * namespace-validated by the caller). `query.filter` is applied client-side
+   * after the search, with the request over-fetching (capped at the service
+   * TopK limit of 100) so filtering doesn't silently drop results below
+   * `topK`; a filtered search can still return fewer than `topK` matches once
+   * the cap truncates the over-fetch.
+   */
+  private async _nativeVectorSearch(
+    query: SearchQuery
+  ): Promise<Array<{ key: string; score: number; metadata?: Record<string, unknown> }>> {
+    if (query.topK < 1 || query.topK > MAX_TOP_K) {
+      throw new StorageError(`topK must be between 1 and ${MAX_TOP_K} (SearchVectors TopK limit); got ${query.topK}`)
+    }
+    if (!query.vector.every((v) => Number.isFinite(v))) {
+      throw new StorageError('Query vector contains non-finite values (NaN/Infinity); the DynamoDB N type rejects them.')
+    }
+    const topK = query.filter !== undefined ? Math.min(query.topK * FILTER_OVERFETCH, MAX_TOP_K) : query.topK
+
+    const { SearchVectorsCommand } = await import('@aws-sdk/client-dynamodb')
+    const { unmarshall } = await import('@aws-sdk/util-dynamodb')
+    const client = await this._getClient()
+    const response = await client.send(
+      new SearchVectorsCommand({
+        TableName: this._tableName,
+        IndexName: this._indexName,
+        SearchVector: query.vector.map((v) => ({ N: String(v) })),
+        TopK: topK,
+        ...(query.pk !== undefined && {
+          SearchConditionExpression: '#pk = :pk',
+          ExpressionAttributeNames: { '#pk': PK },
+          ExpressionAttributeValues: { ':pk': { S: query.pk } },
+        }),
+      })
+    )
+
+    const matches: Array<{ key: string; score: number; metadata?: Record<string, unknown> }> = []
+    for (const result of response.SearchResults ?? []) {
+      if (!result.Item || result.Score === undefined) continue
+      const item = unmarshall(result.Item)
+      const pk = item[PK] as string
+      const sk = (item[SK] as string | undefined) ?? ''
+      const fullKey = sk === '' || sk === '\u0000' ? pk : `${pk}/${sk}`
+      const metadata = item[META_ATTR] as Record<string, unknown> | undefined
+      if (query.filter !== undefined && !DynamoDBStorage._matchesSearchFilter(metadata, query.filter)) continue
+      matches.push({ key: fullKey, score: result.Score, ...(metadata !== undefined && { metadata }) })
+      if (matches.length >= query.topK) break
+    }
+    return matches
+  }
+
+  /** Exact-equality match of every filter entry against item metadata. */
+  private static _matchesSearchFilter(
+    metadata: Record<string, unknown> | undefined,
+    filter: Record<string, string | number | boolean>
+  ): boolean {
+    if (metadata === undefined) return false
+    return Object.entries(filter).every(([k, v]) => metadata[k] === v)
+  }
+
+  // ---------------------------------------------------------------------------
+  // Internals
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Splits a full key into partition and sort keys. The partition is the leading
+   * scope and its identifier (first two segments, e.g. `sessions/<id>`); the sort
+   * key is the remainder. Single-segment keys use the segment as the partition and
+   * a sentinel sort key so point operations round-trip.
+   */
+  private _split(fullKey: string): { pk: string; sk: string } {
+    const segments = fullKey.split('/').filter(Boolean)
+    if (segments.length <= 1) return { pk: segments[0] ?? fullKey, sk: '\u0000' }
+    return { pk: segments.slice(0, 2).join('/'), sk: segments.slice(2).join('/') || '\u0000' }
+  }
+
+  /** True when the item carries a TTL attribute whose epoch-seconds value has passed. */
+  private _isExpired(item: Record<string, unknown>): boolean {
+    const exp = item[this._ttlAttribute]
+    return typeof exp === 'number' && exp <= Math.floor(Date.now() / 1000)
+  }
+
+  /**
+   * Rejects a caller-supplied partition key that falls outside this namespace.
+   *
+   * `write`/`read`/`delete` and the string-prefix `list` all derive the physical
+   * partition from `prefix + key`, so the namespace is enforced by construction. A
+   * {@link DynamoDBListQuery} and {@link SearchQuery} name the partition directly, so
+   * the same boundary is enforced here instead. The partition is rejected rather than
+   * silently rewritten: a caller asking for another namespace's partition has a bug or
+   * is probing, and neither should be answered with quietly different data.
+   *
+   * A partition at or below the namespace is in scope. So is an ancestor partition:
+   * because the physical partition is only the first two key segments, a deeply
+   * namespaced view legitimately lives inside a shallower partition, and any rows
+   * outside the namespace are dropped by {@link _stripPrefix}. A partition on a
+   * different branch (another tenant) is rejected.
+   */
+  private _assertPkInScope(pk: string): void {
+    if (!this._prefix) return
+    const candidate = pk.endsWith('/') ? pk : `${pk}/`
+    if (pk.startsWith(this._prefix) || this._prefix.startsWith(candidate)) return
+    throw new StorageError(
+      `Partition key '${pk}' is outside this storage namespace '${this._prefix}'. ` +
+        `Prefix the partition key with '${this._prefix}' (for example '${this._prefix}sessions') ` +
+        `or use the storage instance that owns it.`
+    )
+  }
+
+  /**
+   * Strips the namespace prefix from a stored key, or returns `null` when the key is
+   * outside this namespace. Guards the de-prefix: slicing blindly would turn another
+   * namespace's key into something that looks like one of ours.
+   */
+  private _stripPrefix(stored: string): string | null {
+    if (!this._prefix) return stored
+    if (!stored.startsWith(this._prefix)) return null
+    return stored.slice(this._prefix.length)
+  }
+
+  private async _listByPrefix(prefix: string): Promise<string[]> {
+    const normalized = normalizePrefix(prefix)
+    const full = `${this._prefix}${normalized}`
+    const segments = full.split('/').filter(Boolean)
+    if (segments.length < 2) {
+      throw new StorageError(
+        `DynamoDB list prefix '${prefix}' is too broad; include at least the scope and identifier (e.g. 'sessions/<id>/'). ` +
+          `Cross-partition listing requires a DynamoDBListQuery or the optional query() extension.`
+      )
+    }
+    const pk = segments.slice(0, 2).join('/')
+    const skPrefix = segments.slice(2).join('/')
+    return this._listByQuery(skPrefix ? { pk, skPrefix } : { pk })
+  }
+
+  private async _listByQuery(query: DynamoDBListQuery): Promise<string[]> {
+    if (query.skPrefix && query.skBetween) {
+      throw new StorageError('DynamoDBListQuery accepts skPrefix or skBetween, not both')
+    }
+    this._assertPkInScope(query.pk)
+    const { QueryCommand } = await import('@aws-sdk/lib-dynamodb')
+    const client = await this._getClient()
+    const keys: string[] = []
+    let exclusiveStartKey: Record<string, unknown> | undefined
+    const names: Record<string, string> = { '#pk': PK, '#k': KEY_ATTR }
+    const values: Record<string, unknown> = { ':pk': query.pk }
+    let condition = '#pk = :pk'
+    if (query.skPrefix !== undefined) {
+      names['#sk'] = SK
+      values[':sk'] = query.skPrefix
+      condition += ' AND begins_with(#sk, :sk)'
+    } else if (query.skBetween !== undefined) {
+      names['#sk'] = SK
+      values[':from'] = query.skBetween[0]
+      values[':to'] = query.skBetween[1]
+      condition += ' AND #sk BETWEEN :from AND :to'
+    }
+    // Hide items past their TTL — only when TTL is opted into. FilterExpression
+    // evaluates the full item server-side (independent of ProjectionExpression) and
+    // adds no RCU cost — the partition is scanned regardless. The attribute_not_exists
+    // clause keeps rows written before TTL was enabled from being dropped.
+    let filterExpression: string | undefined
+    if (this._ttlEnabled) {
+      names['#ttl'] = this._ttlAttribute
+      values[':now'] = Math.floor(Date.now() / 1000)
+      filterExpression = '(attribute_not_exists(#ttl) OR #ttl > :now)'
+    }
+    // DynamoDB's Limit caps items EVALUATED before the FilterExpression, and startAfter
+    // is applied client-side — so pushing Limit while either is active can under-return.
+    // Only push it down when neither is in play; otherwise the client-side count is authoritative.
+    const pushLimit = query.limit && !filterExpression && query.startAfter === undefined ? query.limit : undefined
+    do {
+      const response = await client.send(
+        new QueryCommand({
+          TableName: this._tableName,
+          KeyConditionExpression: condition,
+          FilterExpression: filterExpression,
+          ExpressionAttributeNames: names,
+          ExpressionAttributeValues: values,
+          ProjectionExpression: '#k',
+          ExclusiveStartKey: exclusiveStartKey,
+          Limit: pushLimit,
+        })
+      )
+      for (const item of response.Items ?? []) {
+        const k = item[KEY_ATTR] as string | undefined
+        if (k === undefined) continue
+        const key = this._stripPrefix(k)
+        if (key === null) continue
+        // Apply startAfter during collection (before the limit check) so a limit is
+        // filled with post-cursor keys rather than truncated after the fact.
+        if (query.startAfter !== undefined && key <= query.startAfter) continue
+        keys.push(key)
+        if (query.limit && keys.length >= query.limit) return keys.sort()
+      }
+      exclusiveStartKey = response.LastEvaluatedKey
+    } while (exclusiveStartKey)
+    return keys.sort()
+  }
+
+  private async _put(item: Record<string, unknown>): Promise<void> {
+    const { PutCommand } = await import('@aws-sdk/lib-dynamodb')
+    const client = await this._getClient()
+    await client.send(new PutCommand({ TableName: this._tableName, Item: item }))
+  }
+
+  private async _getClient(): Promise<import('@aws-sdk/lib-dynamodb').DynamoDBDocumentClient> {
+    if (this._client) return this._client
+    const { DynamoDBClient } = await import('@aws-sdk/client-dynamodb')
+    const { DynamoDBDocumentClient } = await import('@aws-sdk/lib-dynamodb')
+    const base = new DynamoDBClient(this._region ? { region: this._region } : {})
+    this._client = DynamoDBDocumentClient.from(base)
+    return this._client
+  }
+
+  private _s3Key(fullKey: string): string {
+    return `${this._s3Prefix}${fullKey}`
+  }
+
+  private async _getS3Client(): Promise<import('@aws-sdk/client-s3').S3Client> {
+    if (this._s3Client) return this._s3Client
+    const { S3Client } = await import('@aws-sdk/client-s3')
+    this._s3Client = new S3Client(this._region ? { region: this._region } : {})
+    return this._s3Client
+  }
+
+  private async _s3Put(fullKey: string, data: Uint8Array): Promise<void> {
+    const { PutObjectCommand } = await import('@aws-sdk/client-s3')
+    const client = await this._getS3Client()
+    await client.send(new PutObjectCommand({ Bucket: this._s3Bucket, Key: this._s3Key(fullKey), Body: data }))
+  }
+
+  private async _s3Get(fullKey: string): Promise<Uint8Array | null> {
+    const { GetObjectCommand } = await import('@aws-sdk/client-s3')
+    const client = await this._getS3Client()
+    const response = await client.send(new GetObjectCommand({ Bucket: this._s3Bucket, Key: this._s3Key(fullKey) }))
+    const body = await response.Body?.transformToByteArray()
+    return body ? new Uint8Array(body) : null
+  }
+
+  private async _s3Delete(fullKey: string): Promise<void> {
+    const { DeleteObjectCommand } = await import('@aws-sdk/client-s3')
+    const client = await this._getS3Client()
+    await client.send(new DeleteObjectCommand({ Bucket: this._s3Bucket, Key: this._s3Key(fullKey) }))
+  }
+}

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -1,0 +1,32 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Community DynamoDB {@link https://www.npmjs.com/package/@strands-agents/sdk | Strands Agents}
+ * storage backend.
+ *
+ * Implements the SDK's unified `Storage` interface so a single `DynamoDBStorage`
+ * instance can be passed to Session Manager, Memory Manager, and any other
+ * subsystem that persists bytes — with optional S3 offload for values above the
+ * DynamoDB item limit and an optional native vector-search hook.
+ *
+ * @example
+ * ```typescript
+ * import { Agent, SessionManager } from '@strands-agents/sdk'
+ * import { DynamoDBStorage } from 'strands-dynamodb-storage'
+ *
+ * const storage = new DynamoDBStorage('agent-data', { region: 'us-east-1' })
+ * const agent = new Agent({ sessionManager: new SessionManager({ storage }) })
+ * ```
+ *
+ * @packageDocumentation
+ */
+
+export { DynamoDBStorage } from './dynamodb-storage.js'
+export type {
+  DynamoDBStorageConfig,
+  DynamoDBListQuery,
+  SearchQuery,
+  SearchResult,
+  VectorSearchAdapter,
+} from './dynamodb-storage.js'

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * Community DynamoDB {@link https://www.npmjs.com/package/@strands-agents/sdk | Strands Agents}
+ * Amazon DynamoDB {@link https://www.npmjs.com/package/@strands-agents/sdk | Strands Agents}
  * storage backend.
  *
  * Implements the SDK's unified `Storage` interface so a single `DynamoDBStorage`

--- a/typescript/src/keys.ts
+++ b/typescript/src/keys.ts
@@ -1,0 +1,49 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { StorageError } from '@strands-agents/sdk'
+
+/**
+ * Validates and normalizes a storage key: collapses runs of `/`, strips leading
+ * and trailing `/`, and rejects empty keys and any `..` segment.
+ *
+ * Behaviourally identical to the Strands SDK's internal key normalization, which
+ * is not part of the public API surface. Reimplemented here so this community
+ * backend does not depend on unexported SDK internals while still producing keys
+ * that are byte-for-byte consistent with the shipped `Storage` implementations.
+ *
+ * @param key - The raw key to normalize
+ * @returns The normalized key
+ * @throws {@link StorageError} if the key is empty or contains a `..` segment
+ */
+export function normalizeKey(key: string): string {
+  const segments = key.split('/').filter(Boolean)
+  if (segments.length === 0) {
+    throw new StorageError('Storage key must not be empty')
+  }
+  if (segments.includes('..')) {
+    throw new StorageError(`Invalid storage key '${key}': '..' path segments are not allowed`)
+  }
+  return segments.join('/')
+}
+
+/**
+ * Normalizes a list prefix: collapses slash runs, strips leading slashes, and
+ * preserves a single trailing slash when the caller supplied one. Unlike a key,
+ * an empty prefix is valid and matches everything.
+ *
+ * Matches the Strands SDK's internal prefix normalization (see {@link normalizeKey}).
+ *
+ * @param prefix - The raw prefix to normalize
+ * @returns The normalized prefix
+ * @throws {@link StorageError} if the prefix contains a `..` segment
+ */
+export function normalizePrefix(prefix: string): string {
+  const parts = prefix.split('/')
+  const segments = parts.filter(Boolean)
+  if (segments.includes('..')) {
+    throw new StorageError(`Invalid storage prefix '${prefix}': '..' path segments are not allowed`)
+  }
+  const joined = segments.join('/')
+  return parts[parts.length - 1] === '' && joined ? `${joined}/` : joined
+}

--- a/typescript/src/keys.ts
+++ b/typescript/src/keys.ts
@@ -8,8 +8,8 @@ import { StorageError } from '@strands-agents/sdk'
  * and trailing `/`, and rejects empty keys and any `..` segment.
  *
  * Behaviourally identical to the Strands SDK's internal key normalization, which
- * is not part of the public API surface. Reimplemented here so this community
- * backend does not depend on unexported SDK internals while still producing keys
+ * is not part of the public API surface. Reimplemented here so this package does
+ * not depend on unexported SDK internals while still producing keys
  * that are byte-for-byte consistent with the shipped `Storage` implementations.
  *
  * @param key - The raw key to normalize

--- a/typescript/test/integ/dynamodb-storage.test.ts
+++ b/typescript/test/integ/dynamodb-storage.test.ts
@@ -1,0 +1,331 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Integration tests — run against REAL DynamoDB + S3 (never DynamoDB Local).
+ *
+ * Gated by RUN_INTEG=1 and AWS credentials in the environment. The suite provisions
+ * its own table (pk/sk string schema, TTL enabled on `expireAt`) and — unless
+ * INTEG_S3_BUCKET is supplied — its own S3 bucket, then tears everything down.
+ *
+ * Run:
+ *   RUN_INTEG=1 AWS_REGION=us-east-1 npm run test:integ
+ *
+ * Optional env: INTEG_TABLE, INTEG_S3_BUCKET (reuse instead of create), AWS_PROFILE.
+ *
+ * Native vector search (`search()`) is covered in vector-search.integ.test.ts
+ * (it provisions its own vector-indexed table).
+ */
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import {
+  CreateTableCommand,
+  DeleteTableCommand,
+  DynamoDBClient,
+  UpdateTimeToLiveCommand,
+  waitUntilTableExists,
+} from '@aws-sdk/client-dynamodb'
+import { DynamoDBDocumentClient, GetCommand } from '@aws-sdk/lib-dynamodb'
+import {
+  CreateBucketCommand,
+  DeleteBucketCommand,
+  DeleteObjectCommand,
+  HeadObjectCommand,
+  ListObjectsV2Command,
+  S3Client,
+} from '@aws-sdk/client-s3'
+import { STSClient, GetCallerIdentityCommand } from '@aws-sdk/client-sts'
+import { DynamoDBStorage } from '../../src/dynamodb-storage.js'
+
+const RUN = process.env.RUN_INTEG === '1'
+const REGION = process.env.AWS_REGION ?? process.env.INTEG_REGION ?? 'us-east-1'
+const STAMP = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+const TABLE = process.env.INTEG_TABLE ?? `strands-ddb-storage-integ-${STAMP}`
+const PROVIDED_BUCKET = process.env.INTEG_S3_BUCKET
+const BUCKET = PROVIDED_BUCKET ?? `strands-ddb-storage-integ-${STAMP}`.toLowerCase()
+
+const bytes = (s: string) => new TextEncoder().encode(s)
+const str = (b: Uint8Array | null) => (b ? new TextDecoder().decode(b) : null)
+function randomBytes(n: number): Uint8Array {
+  const a = new Uint8Array(n)
+  for (let i = 0; i < n; i++) a[i] = (Math.random() * 256) | 0
+  return a
+}
+
+let ddb: DynamoDBClient
+let doc: DynamoDBDocumentClient
+let s3: S3Client
+let createdBucket = false
+
+async function objectExists(key: string): Promise<boolean> {
+  try {
+    await s3.send(new HeadObjectCommand({ Bucket: BUCKET, Key: key }))
+    return true
+  } catch {
+    return false
+  }
+}
+
+beforeAll(async () => {
+  if (!RUN) return
+  ddb = new DynamoDBClient({ region: REGION })
+  doc = DynamoDBDocumentClient.from(ddb)
+  s3 = new S3Client({ region: REGION })
+
+  try {
+    const id = await new STSClient({ region: REGION }).send(new GetCallerIdentityCommand({}))
+    console.log(`[integ] account=${id.Account} region=${REGION} table=${TABLE} bucket=${BUCKET}`)
+  } catch (e) {
+    console.warn('[integ] GetCallerIdentity failed — check credentials', e)
+  }
+
+  await ddb.send(
+    new CreateTableCommand({
+      TableName: TABLE,
+      BillingMode: 'PAY_PER_REQUEST',
+      AttributeDefinitions: [
+        { AttributeName: 'pk', AttributeType: 'S' },
+        { AttributeName: 'sk', AttributeType: 'S' },
+      ],
+      KeySchema: [
+        { AttributeName: 'pk', KeyType: 'HASH' },
+        { AttributeName: 'sk', KeyType: 'RANGE' },
+      ],
+    })
+  )
+  await waitUntilTableExists({ client: ddb, maxWaitTime: 180 }, { TableName: TABLE })
+  await ddb.send(
+    new UpdateTimeToLiveCommand({
+      TableName: TABLE,
+      TimeToLiveSpecification: { AttributeName: 'expireAt', Enabled: true },
+    })
+  )
+
+  if (!PROVIDED_BUCKET) {
+    await s3.send(
+      new CreateBucketCommand({
+        Bucket: BUCKET,
+        ...(REGION !== 'us-east-1' ? { CreateBucketConfiguration: { LocationConstraint: REGION as any } } : {}),
+      })
+    )
+    createdBucket = true
+  }
+})
+
+afterAll(async () => {
+  if (!RUN) return
+  try {
+    await ddb.send(new DeleteTableCommand({ TableName: TABLE }))
+  } catch (e) {
+    console.warn('[integ] table cleanup failed', e)
+  }
+  if (createdBucket) {
+    try {
+      let token: string | undefined
+      do {
+        const listed = await s3.send(new ListObjectsV2Command({ Bucket: BUCKET, ContinuationToken: token }))
+        for (const obj of listed.Contents ?? []) {
+          if (obj.Key) await s3.send(new DeleteObjectCommand({ Bucket: BUCKET, Key: obj.Key }))
+        }
+        token = listed.IsTruncated ? listed.NextContinuationToken : undefined
+      } while (token)
+      await s3.send(new DeleteBucketCommand({ Bucket: BUCKET }))
+    } catch (e) {
+      console.warn('[integ] bucket cleanup failed', e)
+    }
+  }
+})
+
+// One instance per capability, sharing the provisioned client/table/bucket.
+function ddbStorage(opts?: { s3?: boolean; prefix?: string; compression?: 'gzip' | 'none'; ttlSeconds?: number }) {
+  return new DynamoDBStorage(TABLE, {
+    client: doc,
+    ...(opts?.prefix ? { prefix: opts.prefix } : {}),
+    ...(opts?.s3 ? { s3Bucket: BUCKET, s3Client: s3 } : {}),
+    ...(opts?.compression ? { compression: opts.compression } : {}),
+    ...(opts?.ttlSeconds !== undefined ? { ttlSeconds: opts.ttlSeconds } : {}),
+  })
+}
+
+describe.skipIf(!RUN)('DynamoDBStorage integration — point operations', () => {
+  const storage = () => ddbStorage()
+
+  it('round-trips write/read and overwrites', async () => {
+    const s = storage()
+    const key = `sessions/pt-${STAMP}/a`
+    await s.write(key, bytes('hello'))
+    expect(str(await s.read(key))).toBe('hello')
+    await s.write(key, bytes('world'))
+    expect(str(await s.read(key))).toBe('world')
+  })
+
+  it('returns null for a missing key', async () => {
+    expect(await storage().read(`sessions/pt-${STAMP}/missing`)).toBeNull()
+  })
+
+  it('deletes a value and is a no-op for a missing key', async () => {
+    const s = storage()
+    const key = `sessions/pt-${STAMP}/del`
+    await s.write(key, bytes('x'))
+    await s.delete(key)
+    expect(await s.read(key)).toBeNull()
+    await expect(s.delete(key)).resolves.toBeUndefined()
+  })
+
+  it('round-trips a single-segment key', async () => {
+    const s = storage()
+    const key = `singleton-${STAMP}`
+    await s.write(key, bytes('one'))
+    expect(str(await s.read(key))).toBe('one')
+    await s.delete(key)
+  })
+
+  it('rejects empty and traversal keys', async () => {
+    const s = storage()
+    await expect(s.write('', bytes('x'))).rejects.toThrow(/must not be empty/)
+    await expect(s.read('sessions/../etc')).rejects.toThrow(/'\.\.'/)
+  })
+})
+
+describe.skipIf(!RUN)('DynamoDBStorage integration — listing', () => {
+  it('lists a string prefix sorted', async () => {
+    const s = ddbStorage()
+    const base = `sessions/ls-${STAMP}/scopes/agent/a1/immutable_history`
+    await s.write(`${base}/snapshot_2.json`, bytes('2'))
+    await s.write(`${base}/snapshot_1.json`, bytes('1'))
+    await s.write(`${base}/snapshot_3.json`, bytes('3'))
+    expect(await s.list(`${base}/`)).toEqual([
+      `${base}/snapshot_1.json`,
+      `${base}/snapshot_2.json`,
+      `${base}/snapshot_3.json`,
+    ])
+  })
+
+  it('lists via a structured DynamoDBListQuery, skBetween, and startAfter', async () => {
+    const s = ddbStorage()
+    const pk = `sessions/lq-${STAMP}`
+    for (const n of ['1', '2', '3', '4']) await s.write(`${pk}/k/${n}`, bytes(n))
+    expect((await s.list({ pk })).sort()).toEqual([`${pk}/k/1`, `${pk}/k/2`, `${pk}/k/3`, `${pk}/k/4`])
+    expect(await s.list({ pk, skBetween: ['k/2', 'k/3'] })).toEqual([`${pk}/k/2`, `${pk}/k/3`])
+    expect(await s.list({ pk, startAfter: `${pk}/k/2` })).toEqual([`${pk}/k/3`, `${pk}/k/4`])
+  })
+
+  it('namespace() view round-trips and lists against the real table', async () => {
+    const s = ddbStorage()
+    const view = s.namespace(`sessions/ns-${STAMP}`)
+    await view.write('scopes/agent/a1/x', bytes('v'))
+    expect(str(await view.read('scopes/agent/a1/x'))).toBe('v')
+    expect(str(await s.read(`sessions/ns-${STAMP}/scopes/agent/a1/x`))).toBe('v')
+    expect(await view.list('scopes/agent/a1/')).toEqual(['scopes/agent/a1/x'])
+  })
+})
+
+describe.skipIf(!RUN)('DynamoDBStorage integration — S3 offload', () => {
+  it('offloads a >380KB value to S3 and reads it back, with a DDB pointer item', async () => {
+    const s = ddbStorage({ s3: true })
+    const key = `sessions/s3-${STAMP}/big`
+    const payload = randomBytes(400_001) // incompressible-ish, above the inline limit
+    await s.write(key, payload)
+    // DDB item is a pointer, not inline bytes.
+    const raw = await doc.send(new GetCommand({ TableName: TABLE, Key: { pk: `sessions/s3-${STAMP}`, sk: 'big' } }))
+    expect(raw.Item?.s3).toBe(true)
+    expect(raw.Item?.data).toBeUndefined()
+    // Object physically present in S3.
+    expect(await objectExists(key)).toBe(true)
+    // Transparent read-back.
+    expect(await s.read(key)).toEqual(payload)
+    // Delete cleans up the S3 object too.
+    await s.delete(key)
+    expect(await objectExists(key)).toBe(false)
+    expect(await s.read(key)).toBeNull()
+  })
+
+  it('throws on an oversized value when no S3 bucket is configured', async () => {
+    const s = ddbStorage() // no s3
+    await expect(s.write(`sessions/s3-${STAMP}/nobucket`, randomBytes(400_001))).rejects.toThrow(/s3Bucket/)
+  })
+})
+
+describe.skipIf(!RUN)('DynamoDBStorage integration — compression', () => {
+  it('gzips a compressible value inline and reads it back', async () => {
+    const s = ddbStorage({ compression: 'gzip' })
+    const key = `sessions/z-${STAMP}/a`
+    const original = 'A'.repeat(5000)
+    await s.write(key, bytes(original))
+    const raw = await doc.send(new GetCommand({ TableName: TABLE, Key: { pk: `sessions/z-${STAMP}`, sk: 'a' } }))
+    expect(raw.Item?.z).toBe(true)
+    expect(str(await s.read(key))).toBe(original)
+  })
+
+  it('keeps a large-but-compressible value inline (no S3 object written)', async () => {
+    const s = ddbStorage({ compression: 'gzip', s3: true })
+    const key = `sessions/z-${STAMP}/inline-big`
+    const original = 'A'.repeat(800_000) // >380KB raw, gzips far under it
+    await s.write(key, bytes(original))
+    expect(await objectExists(key)).toBe(false) // the cost win: stayed in DynamoDB
+    expect(str(await s.read(key))).toBe(original)
+  })
+
+  it('offloads to S3 when even the compressed value exceeds the item limit', async () => {
+    const s = ddbStorage({ compression: 'gzip', s3: true })
+    const key = `sessions/z-${STAMP}/incompressible`
+    const payload = randomBytes(400_001)
+    await s.write(key, payload)
+    expect(await objectExists(key)).toBe(true)
+    expect(await s.read(key)).toEqual(payload)
+    await s.delete(key)
+  })
+})
+
+describe.skipIf(!RUN)('DynamoDBStorage integration — TTL', () => {
+  it('stamps a future epoch-seconds expiry on the real item', async () => {
+    const s = ddbStorage({ ttlSeconds: 3600 })
+    const key = `sessions/ttl-${STAMP}/a`
+    const before = Math.floor(Date.now() / 1000)
+    await s.write(key, bytes('v'))
+    const raw = await doc.send(new GetCommand({ TableName: TABLE, Key: { pk: `sessions/ttl-${STAMP}`, sk: 'a' } }))
+    expect(typeof raw.Item?.expireAt).toBe('number')
+    expect(raw.Item?.expireAt).toBeGreaterThanOrEqual(before + 3600)
+  })
+
+  it('read and list hide an already-expired item (filter, not physical deletion)', async () => {
+    const s = ddbStorage({ ttlSeconds: 3600 })
+    const pk = `sessions/ttlx-${STAMP}`
+    await s.write(`${pk}/live`, bytes('L'))
+    await s.write(`${pk}/dead`, bytes('D'), { ttlSeconds: -1 }) // expiry in the past
+    expect(await s.read(`${pk}/dead`)).toBeNull()
+    expect(await s.list({ pk })).toEqual([`${pk}/live`])
+  })
+
+  it('a reader that did not opt into TTL still returns the unswept item', async () => {
+    const writer = ddbStorage({ ttlSeconds: 3600 })
+    const key = `sessions/ttlopt-${STAMP}/a`
+    await writer.write(key, bytes('v'), { ttlSeconds: -1 })
+    const reader = ddbStorage() // no ttlSeconds -> no filter injected
+    expect(str(await reader.read(key))).toBe('v')
+  })
+})
+
+describe.skipIf(!RUN)('DynamoDBStorage integration — lazy client construction (no injected client)', () => {
+  it('builds its own DynamoDB client from region and round-trips', async () => {
+    // No `client` -> exercises the lazy dynamic-import + new DynamoDBClient path.
+    const s = new DynamoDBStorage(TABLE, { region: REGION })
+    const key = `sessions/reg-${STAMP}/a`
+    await s.write(key, bytes('hello'))
+    expect(str(await s.read(key))).toBe('hello')
+    expect(await s.list({ pk: `sessions/reg-${STAMP}` })).toEqual([key])
+    await s.delete(key)
+    expect(await s.read(key)).toBeNull()
+  })
+
+  it('builds its own S3 client from region for offload', async () => {
+    // No `s3Client` -> exercises the lazy new S3Client path.
+    const s = new DynamoDBStorage(TABLE, { region: REGION, s3Bucket: BUCKET })
+    const key = `sessions/reg-${STAMP}/big`
+    const payload = randomBytes(400_001)
+    await s.write(key, payload)
+    expect(await objectExists(key)).toBe(true)
+    expect(await s.read(key)).toEqual(payload)
+    await s.delete(key)
+    expect(await objectExists(key)).toBe(false)
+  })
+})

--- a/typescript/test/integ/vector-search.integ.test.ts
+++ b/typescript/test/integ/vector-search.integ.test.ts
@@ -66,34 +66,30 @@ describe.skipIf(!RUN)('DynamoDBStorage — native vector search (live)', () => {
     await client.send(new DeleteTableCommand({ TableName: TABLE }))
   })
 
-  it(
-    'searches natively end to end',
-    async () => {
-      const storage = new DynamoDBStorage(TABLE, { region: REGION, prefix: 'tenant/a/', indexName: INDEX })
-      await storage.write('memories/m1', new TextEncoder().encode('likes window seats'), {
-        vector: [1, 0, 0, 0],
-        metadata: { kind: 'pref' },
-      })
-      await storage.write('memories/m2', new TextEncoder().encode('allergic to peanuts'), {
-        vector: [0, 1, 0, 0],
-      })
+  it('searches natively end to end', async () => {
+    const storage = new DynamoDBStorage(TABLE, { region: REGION, prefix: 'tenant/a/', indexName: INDEX })
+    await storage.write('memories/m1', new TextEncoder().encode('likes window seats'), {
+      vector: [1, 0, 0, 0],
+      metadata: { kind: 'pref' },
+    })
+    await storage.write('memories/m2', new TextEncoder().encode('allergic to peanuts'), {
+      vector: [0, 1, 0, 0],
+    })
 
-      // Eventually consistent: poll until both items are visible to search.
-      const deadline = Date.now() + 300_000
-      let results: SearchResult[] = []
-      for (;;) {
-        results = await storage.search({ vector: [1, 0, 0, 0], topK: 2, pk: 'tenant/a' })
-        if (results.length === 2) break
-        if (Date.now() > deadline) throw new Error('expected both items in search results within 300s')
-        await sleep(5000)
-      }
-      expect(results[0]?.key).toBe('memories/m1') // nearest first
-      expect(results[0]?.metadata).toEqual({ kind: 'pref' })
-      expect(results[0]!.score).toBeLessThanOrEqual(results[1]!.score) // COSINE distance
+    // Eventually consistent: poll until both items are visible to search.
+    const deadline = Date.now() + 300_000
+    let results: SearchResult[] = []
+    for (;;) {
+      results = await storage.search({ vector: [1, 0, 0, 0], topK: 2, pk: 'tenant/a' })
+      if (results.length === 2) break
+      if (Date.now() > deadline) throw new Error('expected both items in search results within 300s')
+      await sleep(5000)
+    }
+    expect(results[0]?.key).toBe('memories/m1') // nearest first
+    expect(results[0]?.metadata).toEqual({ kind: 'pref' })
+    expect(results[0]!.score).toBeLessThanOrEqual(results[1]!.score) // COSINE distance
 
-      const [top] = await storage.search({ vector: [1, 0, 0, 0], topK: 1, pk: 'tenant/a', includeValues: true })
-      expect(new TextDecoder().decode(top?.data)).toBe('likes window seats')
-    },
-    360_000
-  )
+    const [top] = await storage.search({ vector: [1, 0, 0, 0], topK: 1, pk: 'tenant/a', includeValues: true })
+    expect(new TextDecoder().decode(top?.data)).toBe('likes window seats')
+  }, 360_000)
 })

--- a/typescript/test/integ/vector-search.integ.test.ts
+++ b/typescript/test/integ/vector-search.integ.test.ts
@@ -1,0 +1,99 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Integration test for native vector search — real Amazon DynamoDB.
+ *
+ * Gated by RUN_INTEG=1 and AWS credentials. Provisions its own table with a
+ * vector index (SearchSchema HASH on pk so searches can be partition-pinned),
+ * waits for the index to finish backfilling (ACTIVE alone is not ready), then
+ * exercises the native `search()` path end to end. Tears the table down after.
+ *
+ * Run:
+ *   RUN_INTEG=1 AWS_REGION=us-east-1 npm run test:integ
+ */
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { CreateTableCommand, DeleteTableCommand, DescribeTableCommand, DynamoDBClient } from '@aws-sdk/client-dynamodb'
+import { DynamoDBStorage, type SearchResult } from '../../src/index.js'
+
+const RUN = process.env.RUN_INTEG === '1'
+const REGION = process.env.AWS_REGION ?? 'us-east-1'
+const TABLE = `strands-integ-vector-ts-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+const INDEX = 'vector_index'
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
+describe.skipIf(!RUN)('DynamoDBStorage — native vector search (live)', () => {
+  const client = new DynamoDBClient({ region: REGION })
+
+  beforeAll(async () => {
+    await client.send(
+      new CreateTableCommand({
+        TableName: TABLE,
+        BillingMode: 'PAY_PER_REQUEST',
+        AttributeDefinitions: [
+          { AttributeName: 'pk', AttributeType: 'S' },
+          { AttributeName: 'sk', AttributeType: 'S' },
+        ],
+        KeySchema: [
+          { AttributeName: 'pk', KeyType: 'HASH' },
+          { AttributeName: 'sk', KeyType: 'RANGE' },
+        ],
+        VectorIndexes: [
+          {
+            IndexName: INDEX,
+            VectorAttribute: { AttributeName: 'vector' },
+            SearchSchema: [{ AttributeName: 'pk', SearchSchemaElementType: 'HASH' }],
+            Projection: { ProjectionType: 'ALL' },
+            Dimensions: 4,
+            DistanceFunction: 'COSINE',
+          },
+        ],
+      })
+    )
+    // Wait for table + index readiness (Backfilling must be false/absent).
+    const deadline = Date.now() + 600_000
+    for (;;) {
+      const table = (await client.send(new DescribeTableCommand({ TableName: TABLE }))).Table
+      const idx = table?.VectorIndexes?.find((i) => i.IndexName === INDEX)
+      if (table?.TableStatus === 'ACTIVE' && idx?.IndexStatus === 'ACTIVE' && !idx?.Backfilling) break
+      if (Date.now() > deadline) throw new Error('vector index did not become ready within 600s')
+      await sleep(5000)
+    }
+  }, 660_000)
+
+  afterAll(async () => {
+    await client.send(new DeleteTableCommand({ TableName: TABLE }))
+  })
+
+  it(
+    'searches natively end to end',
+    async () => {
+      const storage = new DynamoDBStorage(TABLE, { region: REGION, prefix: 'tenant/a/', indexName: INDEX })
+      await storage.write('memories/m1', new TextEncoder().encode('likes window seats'), {
+        vector: [1, 0, 0, 0],
+        metadata: { kind: 'pref' },
+      })
+      await storage.write('memories/m2', new TextEncoder().encode('allergic to peanuts'), {
+        vector: [0, 1, 0, 0],
+      })
+
+      // Eventually consistent: poll until both items are visible to search.
+      const deadline = Date.now() + 300_000
+      let results: SearchResult[] = []
+      for (;;) {
+        results = await storage.search({ vector: [1, 0, 0, 0], topK: 2, pk: 'tenant/a' })
+        if (results.length === 2) break
+        if (Date.now() > deadline) throw new Error('expected both items in search results within 300s')
+        await sleep(5000)
+      }
+      expect(results[0]?.key).toBe('memories/m1') // nearest first
+      expect(results[0]?.metadata).toEqual({ kind: 'pref' })
+      expect(results[0]!.score).toBeLessThanOrEqual(results[1]!.score) // COSINE distance
+
+      const [top] = await storage.search({ vector: [1, 0, 0, 0], topK: 1, pk: 'tenant/a', includeValues: true })
+      expect(new TextDecoder().decode(top?.data)).toBe('likes window seats')
+    },
+    360_000
+  )
+})

--- a/typescript/tsconfig.build.json
+++ b/typescript/tsconfig.build.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist", "test", "**/*.test.ts"]
+}

--- a/typescript/tsconfig.json
+++ b/typescript/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "types": ["node"],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "skipLibCheck": true
+  },
+  "include": ["src", "test"]
+}

--- a/typescript/vitest.config.ts
+++ b/typescript/vitest.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'vitest/config'
+
+// Unit tests only — fast, offline, no AWS. Integration tests live under test/integ
+// and run via `npm run test:integ` (vitest.integ.config.ts).
+export default defineConfig({
+  resolve: {
+    // The source uses NodeNext-style `.js` import specifiers for `.ts` files.
+    extensionAlias: {
+      '.js': ['.ts', '.js'],
+    },
+  },
+  test: {
+    include: ['src/**/*.test.ts'],
+    exclude: ['test/integ/**', 'node_modules/**', 'dist/**'],
+  },
+})

--- a/typescript/vitest.integ.config.ts
+++ b/typescript/vitest.integ.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from 'vitest/config'
+
+// Integration tests — run against REAL DynamoDB + S3 (never DynamoDB Local).
+// Gated by RUN_INTEG=1 and require AWS credentials in the environment.
+// Table + bucket are provisioned and torn down by the suite itself.
+export default defineConfig({
+  resolve: {
+    extensionAlias: {
+      '.js': ['.ts', '.js'],
+    },
+  },
+  test: {
+    include: ['test/integ/**/*.test.ts'],
+    testTimeout: 120_000,
+    hookTimeout: 300_000,
+    // Real network calls to one shared table/bucket — keep it serial.
+    fileParallelism: false,
+    sequence: { concurrent: false },
+    retry: 0,
+  },
+})


### PR DESCRIPTION
An Amazon DynamoDB implementation of the Strands Agents SDK unified byte `Storage` interface (`write` / `read` / `delete` / `list` / `namespace`), shipped for **both TypeScript and Python** from one repository. One DynamoDB-backed instance serves Session Manager, Memory Manager, the context offloader and transcripts, with no per-subsystem code.

### Design

**Single-table.** The `/`-separated key maps to a partition key (leading scope) plus a sort key (remainder), so point operations are single-item `PutItem` / `GetItem` / `DeleteItem` and `list(prefix)` is a native partition `Query` with `begins_with` rather than a scan. A constructor-bound prefix pins every operation inside its own key space, so two tenants sharing a table resolve the same logical key to physically distinct partitions and neither can read or list into the other's data.

**Values larger than the item limit** are offloaded to Amazon S3 transparently, with the item retaining a pointer, so callers see one byte contract regardless of size. Compression (gzip) and TTL are opt-in.

**Semantic search** calls `SearchVectors` natively against a DynamoDB vector index, with the search condition pinned to the caller's partition so a query cannot cross the prefix boundary. `TopK` is bounded, non-finite vector values are rejected before the call, and score semantics are documented per distance function.

### Verification

Python 49 passed with 6 skipped, TypeScript 58 passed, `tsc` clean, `eslint` no errors. Both languages carry live integration suites that run against real DynamoDB and S3, provisioning a vector-indexed table, waiting out index backfill and asserting nearest-first ordering, metadata round-trip and teardown.

### CI and releases

`code-scanning.yml` runs CodeQL for both languages and uploads SARIF so findings surface in the Security tab, with Semgrep and Bandit failing the build directly so scanning holds on pull requests where SARIF upload is unavailable. A weekly schedule re-runs the rule set against existing code, `dependency-review-action` gates pull requests at high severity, and Dependabot covers pip, npm and actions. `CODEOWNERS` scopes review to the maintainers.

Publish workflows verify a language-prefixed tag (`python-v*`, `typescript-v*`) before releasing, so the two languages version independently and a mistyped tag cannot publish.
