### PR TITLE
Publish to npm via OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish-typescript.yml
+++ b/.github/workflows/publish-typescript.yml
@@ -38,7 +38,9 @@ jobs:
     if: needs.check-tag.outputs.should_publish == 'true'
     runs-on: ubuntu-latest
     # Create an `npm` environment in repo settings to gate publishes behind
-    # required reviewers, and scope the NPM_TOKEN secret to it.
+    # required reviewers. Publishing uses npm trusted publishing (OIDC): register
+    # this repository + workflow + environment as a trusted publisher on the
+    # npm package settings. No token is stored anywhere.
     environment:
       name: npm
     permissions:
@@ -54,8 +56,10 @@ jobs:
         with:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
-          cache: 'npm'
-          cache-dependency-path: typescript/package-lock.json
+
+      # Node 22 bundles npm 10, but OIDC trusted publishing needs npm >= 11.5.1.
+      - name: Upgrade npm for trusted publishing
+        run: npm install -g npm@latest && npm --version
 
       - name: Install dependencies
         run: npm ci
@@ -66,7 +70,7 @@ jobs:
       - name: Build
         run: npm run build
 
+      # Authenticates via the OIDC token exchange (id-token: write), which also
+      # generates and uploads the provenance attestation. No NODE_AUTH_TOKEN.
       - name: Publish
         run: npm publish --access public --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Removes the long-lived `NPM_TOKEN` from the npm publish path in favour of OIDC trusted publishing, matching internal secure-release guidance to embrace the registry's own trust mechanism. The registry trusts this repository + workflow + environment directly, no credential exists to leak or rotate, and the provenance attestation is generated in the same exchange. The job upgrades npm first (Node 22 bundles npm 10; trusted publishing needs >= 11.5.1) and dependency caching is removed from the release job so a release build cannot consume a cache that pull request workflows can write to.

The PyPI workflow already publishes via OIDC (`pypa/gh-action-pypi-publish` with `id-token: write`) and needs no change.

**One-time registry setup, requires the `dynamodb-opensource` account:**
- npm: package settings for `strands-dynamodb-storage` -> Trusted Publisher -> `aws/strands-dynamodb-storage`, workflow `publish-typescript.yml`, environment `npm`
- PyPI: project settings for `strands-dynamodb-storage` -> Publishing -> add trusted publisher `aws/strands-dynamodb-storage`, workflow `publish-python.yml`, environment `pypi`
- Then delete the `NPM_TOKEN` secret from this repo and revoke the token on npm
