### PR TITLE
Assign code ownership to the dynamodb-opensource team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,4 +3,6 @@
 
 # Every change requires review from a maintainer. Branch protection on main is
 # configured to require CODEOWNERS review, so this file is what enforces it.
-* @LeeroyHannigan
+# Ownership sits with the team rather than an individual so maintainer changes
+# are a team-membership edit, not a CODEOWNERS commit.
+* @aws/dynamodb-opensource


### PR DESCRIPTION
Points `CODEOWNERS` at `@aws/dynamodb-opensource` instead of an individual account. The team already holds admin on this repository, which satisfies GitHub's requirement that a CODEOWNERS team have explicit access for the entry to take effect. Adding or removing a maintainer becomes a team-membership change rather than a CODEOWNERS commit.

The team currently has one member; a second maintainer should join before strict branch protection (required code owner review) is restored at the public flip.