### PR TITLE
Reclaim the offloaded S3 object on shrink-overwrite; fix stale vector docs

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -29,6 +29,11 @@ store = DynamoDBStorage("agent-data", region_name="us-east-1")
 await store.write("sessions/s1/snapshot.json", b'{"turn": 1}')
 data = await store.read("sessions/s1/snapshot.json")           # bytes | None
 keys = await store.list("sessions/s1/")                         # native Query
+# Note: prefixes must cover at least a full scope and identifier ("scope/id/").
+# list("") and single-segment prefixes are rejected as too broad -- they would
+# require a cross-partition Scan. This deliberately narrows the SDK Storage
+# contract (whose in-memory backends list everything on ""); SDK subsystems
+# always pass namespaced prefixes and are unaffected.
 scoped = await store.list(DynamoDBListQuery(pk="sessions/s1", sk_prefix="scopes/"))
 await store.delete("sessions/s1/snapshot.json")
 ```

--- a/python/src/strands_dynamodb_storage/dynamodb_storage.py
+++ b/python/src/strands_dynamodb_storage/dynamodb_storage.py
@@ -172,10 +172,14 @@ class DynamoDBStorage:
             client: Pre-configured low-level DynamoDB client.
             prefix: Key prefix prepended to every key (a namespace within the table).
             s3_bucket: Bucket for offloading values above the item-size limit.
+                If DynamoDB TTL reaps an offloaded item, only the pointer item is
+                removed; configure an S3 lifecycle rule to reap orphaned objects.
             s3_prefix: Key prefix for offloaded S3 objects.
             s3_client: Pre-configured S3 client. Ignored unless ``s3_bucket`` is set.
             compression: ``"gzip"`` for transparent compression, or ``"none"``.
-            ttl_seconds: Default TTL. Setting it opts in to TTL (stamp + read/list filter).
+            ttl_seconds: Default TTL. Setting it opts in to TTL (stamp + read/list
+                filter). A per-write ``ttl_seconds`` override applies only when the
+                instance opted in here.
             ttl_attribute: Item attribute holding the epoch-seconds TTL.
             index_name: Vector index name (for ``search``).
             vector_attribute: Item attribute holding the embedding vector.
@@ -259,9 +263,22 @@ class DynamoDBStorage:
                     )
                 await self._s3_put(full, payload)
                 item = {_PK: {"S": pk}, _SK: {"S": sk}, _KEY_ATTR: {"S": full}, _S3_ATTR: {"BOOL": True}, **extra}
+                await self._put(item)
             else:
                 item = {_PK: {"S": pk}, _SK: {"S": sk}, _KEY_ATTR: {"S": full}, _DATA_ATTR: {"B": payload}, **extra}
-            await self._put(item)
+                # An overwrite can shrink a previously offloaded value back inline.
+                # Ask for the replaced item so the now-unreferenced S3 object can be
+                # reclaimed: the new item carries no s3 flag, so without this the
+                # object is orphaned forever (a later delete() never reaches it).
+                old = await self._put(item, return_old=bool(self._s3_bucket))
+                if old.get(_S3_ATTR, {}).get("BOOL"):
+                    try:
+                        await self._s3_delete(full)
+                    except Exception:  # noqa: BLE001
+                        # Best-effort: the write itself is durable, so a failed
+                        # cleanup must not fail it. An S3 lifecycle rule is the
+                        # backstop for missed reclamations.
+                        pass
         except StorageError:
             raise
         except Exception as error:
@@ -630,9 +647,14 @@ class DynamoDBStorage:
                 break
         return sorted(keys)
 
-    async def _put(self, item: dict[str, Any]) -> None:
+    async def _put(self, item: dict[str, Any], *, return_old: bool = False) -> dict[str, Any]:
         client = self._get_client()
-        await asyncio.to_thread(client.put_item, TableName=self._table_name, Item=item)
+        kwargs: dict[str, Any] = {"TableName": self._table_name, "Item": item}
+        if return_old:
+            kwargs["ReturnValues"] = "ALL_OLD"
+        response = await asyncio.to_thread(client.put_item, **kwargs)
+        attributes: dict[str, Any] = response.get("Attributes", {})
+        return attributes
 
     def _s3_key(self, full_key: str) -> str:
         return f"{self._s3_prefix}{full_key}"

--- a/python/tests/test_dynamodb_storage.py
+++ b/python/tests/test_dynamodb_storage.py
@@ -199,6 +199,50 @@ async def test_small_value_inline(aws):
     assert await s.read("sessions/s1/small") == b"tiny"
 
 
+async def test_shrink_overwrite_reclaims_offloaded_s3_object(aws):
+    """Offloaded -> inline overwrite must delete the now-unreferenced S3 object."""
+    ddb, s3 = aws
+    s = make(aws, s3_bucket=BUCKET)
+    await s.write("sessions/s1/doc", b"Z" * 400_001)
+    assert s3_exists(s3, "sessions/s1/doc")
+    await s.write("sessions/s1/doc", b"small now")
+    item = raw_item(ddb, "sessions/s1/doc")
+    assert "s3" not in item and item["data"]["B"] == b"small now"
+    assert not s3_exists(s3, "sessions/s1/doc")  # reclaimed, not orphaned
+    assert await s.read("sessions/s1/doc") == b"small now"
+    await s.delete("sessions/s1/doc")  # still clean end-to-end
+
+
+async def test_inline_overwrite_never_touches_s3(aws):
+    """Negative control: inline -> inline overwrite must not attempt S3 cleanup."""
+    s = make(aws, s3_bucket=BUCKET)
+    await s.write("sessions/s1/doc", b"one")
+    with mock.patch.object(s, "_s3_delete", wraps=s._s3_delete) as spy:
+        await s.write("sessions/s1/doc", b"two")
+        spy.assert_not_called()
+    assert await s.read("sessions/s1/doc") == b"two"
+
+
+async def test_offloaded_overwrite_keeps_object_readable(aws):
+    """Offloaded -> offloaded overwrite reuses the deterministic object key."""
+    _, s3 = aws
+    s = make(aws, s3_bucket=BUCKET)
+    await s.write("sessions/s1/doc", b"A" * 400_001)
+    await s.write("sessions/s1/doc", b"B" * 400_002)
+    assert s3_exists(s3, "sessions/s1/doc")
+    assert await s.read("sessions/s1/doc") == b"B" * 400_002
+
+
+async def test_s3_cleanup_failure_does_not_fail_the_write(aws):
+    """The shrink-overwrite reclamation is best-effort: the write must survive it."""
+    _, s3 = aws
+    s = make(aws, s3_bucket=BUCKET)
+    await s.write("sessions/s1/doc", b"Z" * 400_001)
+    with mock.patch.object(s, "_s3_delete", side_effect=RuntimeError("s3 down")):
+        await s.write("sessions/s1/doc", b"small now")  # must not raise
+    assert await s.read("sessions/s1/doc") == b"small now"
+
+
 # ------------------------------------------------------------------- compression
 
 

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -53,6 +53,12 @@ const bytes = await store.read('sessions/s1/snapshot.json')   // Uint8Array | nu
 // list by string prefix -> a native partition Query with begins_with
 const keys = await store.list('sessions/s1/')
 
+// Note: prefixes must cover at least a full scope and identifier ('scope/id/').
+// list('') and single-segment prefixes are rejected as too broad -- they would
+// require a cross-partition Scan. This deliberately narrows the SDK Storage
+// contract (whose in-memory backends list everything on ''); SDK subsystems
+// always pass namespaced prefixes and are unaffected.
+
 // or a structured DynamoDB query (the intended pk/sk extension point) — no GSI
 const scoped = await store.list({ pk: 'sessions/s1', skPrefix: 'scopes/agent/' })
 
@@ -128,12 +134,13 @@ await store.write('memory/u1/m1', new TextEncoder().encode('likes window seats')
 const results = await store.search({
   vector: queryEmbedding,
   topK: 5,
-  pk: 'memory/u1',          // required: the index HASH key
+  pk: 'memory/u1',          // required when the index declares a HASH element
   filter: { kind: 'preference' },   // optional server-side metadata filter
   includeValues: true,      // hydrate each match's stored bytes
 })
 // results: Array<{ key: string; score: number; data?: Uint8Array; metadata?: Record<string, unknown> }>
-// ordered nearest-first; score is higher = nearer.
+// ordered nearest-first; score direction follows the index's distance function
+// (COSINE/EUCLIDEAN: lower = nearer; DOT_PRODUCT: higher = more similar).
 ```
 
 ### The `vectorSearch` adapter (optional override)
@@ -154,8 +161,7 @@ type VectorSearchAdapter = (params: {
 }) => Promise<Array<{ key: string; score: number; metadata?: Record<string, unknown> }>>
 ```
 
-At GA this becomes a ~10-line wrapper over `SearchVectorsCommand`. Until then, provide your own adapter (or use the
-reference recipe) — without one, `search()` throws a clear error instead of silently degrading.
+The adapter is purely an override: with none configured, `search()` issues the native `SearchVectorsCommand` itself.
 
 ## Configuration reference
 

--- a/typescript/src/dynamodb-storage.test.ts
+++ b/typescript/src/dynamodb-storage.test.ts
@@ -45,8 +45,10 @@ class FakeDocumentClient {
       return { SearchResults: scored }
     }
     if (command instanceof PutCommand) {
-      this.items.set(this._k(input.Item.pk, input.Item.sk), input.Item)
-      return {}
+      const key = this._k(input.Item.pk, input.Item.sk)
+      const old = this.items.get(key)
+      this.items.set(key, input.Item)
+      return input.ReturnValues === 'ALL_OLD' && old ? { Attributes: old } : {}
     }
     if (command instanceof GetCommand) {
       return { Item: this.items.get(this._k(input.Key.pk, input.Key.sk)) }
@@ -284,6 +286,48 @@ describe('DynamoDBStorage — S3 offload', () => {
     await storage.delete('sessions/s1/big')
     expect(s3.objects.size).toBe(0)
     expect(await storage.read('sessions/s1/big')).toBeNull()
+  })
+
+  it('shrink-overwrite reclaims the offloaded S3 object', async () => {
+    const { storage, s3, client } = newStorage({ s3: true })
+    await storage.write('sessions/s1/doc', bytes('Z'.repeat(400_001)))
+    expect(s3.objects.size).toBe(1)
+    await storage.write('sessions/s1/doc', bytes('small now'))
+    const item = [...client.items.values()][0]!
+    expect(item.s3).toBeUndefined()
+    expect(s3.objects.size).toBe(0) // reclaimed, not orphaned
+    expect(str(await storage.read('sessions/s1/doc'))).toBe('small now')
+  })
+
+  it('inline-overwrite never touches S3 (negative control)', async () => {
+    const { storage, s3 } = newStorage({ s3: true })
+    const sends: unknown[] = []
+    const realSend = s3.send.bind(s3)
+    s3.send = async (c: any) => (sends.push(c), realSend(c))
+    await storage.write('sessions/s1/doc', bytes('one'))
+    await storage.write('sessions/s1/doc', bytes('two'))
+    expect(sends).toHaveLength(0)
+    expect(str(await storage.read('sessions/s1/doc'))).toBe('two')
+  })
+
+  it('offloaded-overwrite keeps the object readable (deterministic key reuse)', async () => {
+    const { storage, s3 } = newStorage({ s3: true })
+    await storage.write('sessions/s1/doc', bytes('A'.repeat(400_001)))
+    await storage.write('sessions/s1/doc', bytes('B'.repeat(400_002)))
+    expect(s3.objects.size).toBe(1)
+    expect(str(await storage.read('sessions/s1/doc'))).toBe('B'.repeat(400_002))
+  })
+
+  it('a failed S3 reclamation does not fail the write (best-effort)', async () => {
+    const { storage, s3 } = newStorage({ s3: true })
+    await storage.write('sessions/s1/doc', bytes('Z'.repeat(400_001)))
+    const realSend = s3.send.bind(s3)
+    s3.send = async (c: any) => {
+      if (c instanceof DeleteObjectCommand) throw new Error('s3 down')
+      return realSend(c)
+    }
+    await storage.write('sessions/s1/doc', bytes('small now')) // must not throw
+    expect(str(await storage.read('sessions/s1/doc'))).toBe('small now')
   })
 
   it('throws on an oversized value when no S3 bucket is configured', async () => {

--- a/typescript/src/dynamodb-storage.ts
+++ b/typescript/src/dynamodb-storage.ts
@@ -45,7 +45,7 @@ export interface SearchQuery {
   vector: number[]
   /** Number of nearest neighbours to return. */
   topK: number
-  /** Optional partition/scope to search within. */
+  /** Partition/scope to search within. Required when the index's SearchSchema declares a HASH element; omit otherwise. */
   pk?: string
   /** Optional metadata pre-filter (equality). */
   filter?: Record<string, string | number | boolean>
@@ -57,7 +57,7 @@ export interface SearchQuery {
 export interface SearchResult {
   /** Storage key of the matched item (with any constructor prefix stripped). */
   key: string
-  /** Similarity score (backend-defined; higher is nearer for cosine/dot). */
+  /** Raw index score; direction depends on the index's distance function: lower is nearer for COSINE/EUCLIDEAN, higher for DOT_PRODUCT. */
   score: number
   /** Stored bytes, present only when `includeValues` was requested. */
   data?: Uint8Array
@@ -111,6 +111,7 @@ export interface DynamoDBStorageConfig {
    * TTL reaps it, and `read`/`list` filter out items whose expiry has already passed —
    * covering the up-to-~48h lag before DynamoDB physically deletes them. A per-write
    * `ttlSeconds` tunes the duration for that write.
+   * On an instance that did not opt in here, a per-write `ttlSeconds` is ignored.
    *
    * Physical cleanup requires TTL enabled on that attribute at the table level. When
    * combined with S3 offload, expiry removes only the DynamoDB pointer item — configure
@@ -123,7 +124,7 @@ export interface DynamoDBStorageConfig {
   indexName?: string
   /** Item attribute holding the embedding vector. Default `'vector'`. */
   vectorAttribute?: string
-  /** Adapter that performs the native vector search. Required to use `search()` until GA. */
+  /** Optional override of the native `SearchVectors` call (testing, custom routing). When unset, `search()` calls DynamoDB natively. */
   vectorSearch?: VectorSearchAdapter
 }
 
@@ -258,7 +259,23 @@ export class DynamoDBStorage implements Storage<string | DynamoDBListQuery> {
         await this._s3Put(full, payload)
         await this._put({ [PK]: pk, [SK]: sk, [KEY_ATTR]: full, [S3_ATTR]: true, ...extra })
       } else {
-        await this._put({ [PK]: pk, [SK]: sk, [KEY_ATTR]: full, [DATA_ATTR]: payload, ...extra })
+        // An overwrite can shrink a previously offloaded value back inline. Ask for
+        // the replaced item so the now-unreferenced S3 object can be reclaimed: the
+        // new item carries no s3 flag, so without this the object is orphaned
+        // forever (a later delete() never reaches it).
+        const old = await this._put(
+          { [PK]: pk, [SK]: sk, [KEY_ATTR]: full, [DATA_ATTR]: payload, ...extra },
+          { returnOld: Boolean(this._s3Bucket) }
+        )
+        if (old?.[S3_ATTR]) {
+          try {
+            await this._s3Delete(full)
+          } catch {
+            // Best-effort: the write itself is durable, so a failed cleanup must
+            // not fail it. An S3 lifecycle rule is the backstop for missed
+            // reclamations.
+          }
+        }
       }
     } catch (error: unknown) {
       if (error instanceof StorageError) throw error
@@ -639,10 +656,20 @@ export class DynamoDBStorage implements Storage<string | DynamoDBListQuery> {
     return keys.sort()
   }
 
-  private async _put(item: Record<string, unknown>): Promise<void> {
+  private async _put(
+    item: Record<string, unknown>,
+    options?: { returnOld?: boolean }
+  ): Promise<Record<string, unknown> | undefined> {
     const { PutCommand } = await import('@aws-sdk/lib-dynamodb')
     const client = await this._getClient()
-    await client.send(new PutCommand({ TableName: this._tableName, Item: item }))
+    const response = await client.send(
+      new PutCommand({
+        TableName: this._tableName,
+        Item: item,
+        ...(options?.returnOld ? { ReturnValues: 'ALL_OLD' as const } : {}),
+      })
+    )
+    return response.Attributes
   }
 
   private async _getClient(): Promise<import('@aws-sdk/lib-dynamodb').DynamoDBDocumentClient> {


### PR DESCRIPTION
Fixes the one code defect found by two independent hostile reviews run live against real DynamoDB and the real Strands SDKs (Python `strands-agents` 1.52.0; TypeScript `@strands-agents/sdk` 1.10.0 floor and 1.13.0), plus the documentation drift those reviews surfaced.

**The bug.** Overwriting an S3-offloaded value with one that now fits inline rewrote the item without the `s3` flag and never deleted the old S3 object. Nothing could reclaim it afterwards -- `delete()` keys off the flag that was just dropped. A permanent, silent storage leak, identical in both languages, proven live in both reviews.

**The fix.** The inline write branch asks `PutItem` for `ALL_OLD` (only when a bucket is configured, so the plain path is untouched) and best-effort deletes the S3 object when the replaced item carried the `s3` flag. Best-effort is deliberate: the write is durable by that point, so a failed cleanup must not fail it; an S3 lifecycle rule remains the backstop. Offloaded-to-offloaded overwrites reuse the deterministic object key and need no cleanup.

**Tests.** Ten new regression tests across the two languages: reclamation on shrink-overwrite, a negative control proving inline-to-inline overwrites make no S3 call, deterministic key reuse, and write survival when the S3 cleanup itself fails. The Python shrink test was verified discriminating against a sabotaged fix.

**Doc corrections.** The TypeScript README and config TSDoc still called the `vectorSearch` adapter required "until GA" when the shipped code calls `SearchVectors` natively (it is an optional override); the README's score comment said higher = nearer, backwards for COSINE/EUCLIDEAN; `SearchQuery.pk` is now documented as conditionally required; per-write TTL overrides are documented as requiring construction-time opt-in; Python gained the TTL+offload lifecycle-rule caveat TypeScript already had; both READMEs document the deliberate `list()` narrowing.

Gates: Python ruff format + check + mypy --strict + 53 passed / 6 skipped; TypeScript prettier + eslint (0 errors) + tsc + 62 passed + build.