### PR TITLE
Document provisioning, permissions, and the semantic search journey

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,83 @@ await storage.list('sessions/s1/')
 
 More in the [TypeScript README](typescript/), including the structured `DynamoDBListQuery` extension and typed search results.
 
+## Provisioning and permissions
+
+**You own the table.** The package never creates infrastructure: it holds no `CreateTable` or `UpdateTable` permission at runtime, so the table lives in your infrastructure as code next to your other resources, with your tagging, backup, and encryption posture applied. Everything it needs is a table with a string partition key `pk` and a string sort key `sk`:
+
+```bash
+aws dynamodb create-table \
+  --table-name agent-storage \
+  --attribute-definitions AttributeName=pk,AttributeType=S AttributeName=sk,AttributeType=S \
+  --key-schema AttributeName=pk,KeyType=HASH AttributeName=sk,KeyType=RANGE \
+  --billing-mode PAY_PER_REQUEST
+```
+
+On-demand billing suits agent traffic, which is bursty and idles at zero, but provisioned capacity works identically.
+
+**TTL (optional).** Constructing the storage with a TTL stamps an epoch-seconds `expireAt` attribute on every item and filters already-expired items on `read` / `list`. For DynamoDB to physically reap expired items, enable TTL on the table once:
+
+```bash
+aws dynamodb update-time-to-live \
+  --table-name agent-storage \
+  --time-to-live-specification "Enabled=true, AttributeName=expireAt"
+```
+
+**Semantic search (optional).** `search()` runs against a DynamoDB vector index on the same table. The index is created with the table (its name, dimensions, and distance function are immutable afterwards), so size `Dimensions` to your embedding model:
+
+```bash
+aws dynamodb create-table \
+  --table-name agent-storage \
+  --attribute-definitions AttributeName=pk,AttributeType=S AttributeName=sk,AttributeType=S \
+  --key-schema AttributeName=pk,KeyType=HASH AttributeName=sk,KeyType=RANGE \
+  --billing-mode PAY_PER_REQUEST \
+  --vector-indexes '[{
+    "IndexName": "vector_index",
+    "VectorAttribute": {"AttributeName": "vector"},
+    "SearchSchema": [{"AttributeName": "pk", "SearchSchemaElementType": "HASH"}],
+    "Projection": {"ProjectionType": "ALL"},
+    "Dimensions": 1024,
+    "DistanceFunction": "COSINE"
+  }]'
+```
+
+The `SearchSchema` HASH element on `pk` partitions the index the same way the table is partitioned, so every search is scoped to one key space and one tenant's memories can never surface in another's results. A newly created index backfills before it is searchable; wait for `IndexStatus: ACTIVE` with `Backfilling` false in `describe-table` before the first search. The index names above (`vector_index`, `vector`) are the package defaults; both are configurable. Requires an up-to-date AWS CLI, and SDK floors of `boto3 >= 1.43.64` / `@aws-sdk/client-dynamodb >= 3.1103.0`.
+
+**S3 offload (optional).** Values above the DynamoDB item-size limit offload to a bucket you provide (`s3Bucket` / `s3_bucket`); objects are keyed by the item's full storage key under an optional prefix. Overwrites and deletes reclaim the object, and if you enable TTL, add an S3 lifecycle rule as the backstop: DynamoDB reaping an expired pointer item does not delete its S3 object.
+
+**Runtime permissions.** The package issues exactly these operations, so least privilege is:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "AgentStorageTable",
+      "Effect": "Allow",
+      "Action": ["dynamodb:PutItem", "dynamodb:GetItem", "dynamodb:DeleteItem", "dynamodb:Query"],
+      "Resource": "arn:aws:dynamodb:us-east-1:123456789012:table/agent-storage"
+    },
+    {
+      "Sid": "SemanticSearchOptional",
+      "Effect": "Allow",
+      "Action": "dynamodb:SearchVectors",
+      "Resource": [
+        "arn:aws:dynamodb:us-east-1:123456789012:table/agent-storage",
+        "arn:aws:dynamodb:us-east-1:123456789012:table/agent-storage/index/*"
+      ]
+    },
+    {
+      "Sid": "S3OffloadOptional",
+      "Effect": "Allow",
+      "Action": ["s3:PutObject", "s3:GetObject", "s3:DeleteObject"],
+      "Resource": "arn:aws:s3:::my-offload-bucket/*"
+    }
+  ]
+}
+```
+
+Drop the optional statements for features you don't use. Nothing else is required: no `DescribeTable`, no `Scan`, no table-level wildcards, and credentials resolve through the standard SDK chain (environment, instance profile, or an injected client).
+
 ## Features
 
 Both languages ship the same capabilities with identical semantics.

--- a/python/README.md
+++ b/python/README.md
@@ -47,6 +47,46 @@ await store.delete("sessions/s1/snapshot.json")
 - Native vector `search()` via Amazon DynamoDB vector indexes (`SearchVectors`,
   requires boto3 >= 1.43.64); a `vector_search` adapter can override the call.
 
+## Semantic search
+
+`search()` gives an agent semantic long-term memory over the same table: write each memory
+with its embedding, then query by meaning. Scoring runs *in the database* against a DynamoDB
+vector index (no second vector store, no ETL), and because the index is partitioned on `pk`,
+every search is scoped to the caller's key space -- one tenant's memories can never surface
+in another's results. Creating the table with a vector index (and the IAM permissions needed)
+is covered in the repository README's [Provisioning and permissions](../#provisioning-and-permissions).
+
+```python
+from strands_dynamodb_storage import DynamoDBStorage, SearchQuery
+
+store = DynamoDBStorage("agent-memory", region_name="us-east-1", prefix="user/u1")
+
+# store a memory with its embedding (kept inline even when the payload offloads to S3)
+await store.write(
+    "memories/m1",
+    b"likes window seats",
+    vector=embed("likes window seats"),   # your embedding model, e.g. 1024 floats
+    metadata={"kind": "preference"},
+)
+
+# recall by meaning, scoped to this store's partition
+results = await store.search(SearchQuery(
+    vector=embed("seating preferences?"),
+    top_k=5,
+    pk="user/u1/memories",                # required: the index declares a HASH element
+    filter={"kind": "preference"},        # optional metadata equality filter
+    include_values=True,                  # hydrate each match's stored bytes
+))
+for r in results:
+    print(r.key, r.score, r.data)
+# ordered most-similar-first; score direction follows the index's distance function
+# (COSINE/EUCLIDEAN: lower = nearer; DOT_PRODUCT: higher = more similar)
+```
+
+Like a global secondary index, the vector index is eventually consistent, and a freshly
+created index backfills before it is searchable. Requires `boto3 >= 1.43.64`; a
+`vector_search` adapter, when configured, overrides the native call (testing, custom routing).
+
 ## Development
 
 ```bash

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -29,6 +29,9 @@ aws dynamodb create-table --table-name agent-data \
   --billing-mode PAY_PER_REQUEST --region us-east-1
 ```
 
+You own the table: the package never creates infrastructure and holds no `CreateTable` permission at runtime. TTL
+enablement and vector index creation are covered in [Provisioning and permissions](../#provisioning-and-permissions).
+
 ## Quick start — session persistence, zero custom code
 
 ```ts
@@ -106,22 +109,24 @@ Stamps a DynamoDB-native epoch-seconds `expireAt` attribute (enable TTL on that 
 cleanup). `read`/`list` also filter items whose expiry has passed, covering the lag before DynamoDB physically deletes
 them. With S3 offload, add an S3 lifecycle rule to reclaim offloaded objects (TTL removes only the DynamoDB pointer).
 
-## Vector search — DynamoDB native vector index
+## Semantic search — DynamoDB native vector index
 
-`search()` is an optional, feature-detected part of the `Storage` contract: consumers do `if (storage.search) { … }` and
-fall back to client-side KNN when a backend doesn't implement it. On DynamoDB it runs against the **native vector index**,
-so nearest-neighbour scoring happens *in the database*.
+`search()` gives an agent semantic long-term memory over the same table: write each memory with its embedding, then
+query by meaning. It is an optional, feature-detected part of the `Storage` contract: consumers do `if (storage.search) { … }`
+and fall back to client-side KNN when a backend doesn't implement it. On DynamoDB it runs against the **native vector
+index**, so nearest-neighbour scoring happens *in the database* -- no second vector store, no ETL -- and because the index
+is partitioned on `pk`, every search is scoped to the caller's key space. Creating the table with a vector index (and the
+IAM permissions needed) is covered in the repository README's [Provisioning and permissions](../#provisioning-and-permissions).
 
 Write an embedding alongside the bytes, then query:
 
 ```ts
-import { DynamoDBStorage, type VectorSearchAdapter } from 'strands-dynamodb-storage'
+import { DynamoDBStorage } from 'strands-dynamodb-storage'
 
 const store = new DynamoDBStorage('agent-memory', {
   region: 'us-east-1',
-  indexName: 'vector_index',        // vector index on the table
-  vectorAttribute: 'vector',
-  vectorSearch: myAdapter,          // adapter that issues DynamoDB SearchVectors (see below)
+  indexName: 'vector_index',        // vector index on the table (the default)
+  vectorAttribute: 'vector',        // item attribute holding the embedding (the default)
 })
 
 // store a memory with its embedding (kept inline even when the payload offloads to S3)
@@ -191,8 +196,18 @@ The adapter is purely an override: with none configured, `search()` issues the n
 }
 ```
 
-(The S3 statement is only needed when `s3Bucket` is configured. Vector `search()` additionally needs the DynamoDB
-vector-search action on the table/index once that API is generally available.)
+(The S3 statement is only needed when `s3Bucket` is configured. Semantic `search()` additionally needs
+`dynamodb:SearchVectors` on the table and its indexes:)
+
+```json
+{ "Effect": "Allow",
+  "Action": "dynamodb:SearchVectors",
+  "Resource": ["arn:aws:dynamodb:us-east-1:ACCOUNT:table/agent-data",
+               "arn:aws:dynamodb:us-east-1:ACCOUNT:table/agent-data/index/*"] }
+```
+
+The full provisioning story (TTL enablement, vector index creation, and the complete least-privilege policy) is in the
+repository README's [Provisioning and permissions](../#provisioning-and-permissions).
 
 ## License
 


### PR DESCRIPTION
Closes the two gaps a reader could not resolve from the docs alone: **who creates the table** and **how to use semantic search**.

**Root README: new "Provisioning and permissions" section.** States the ownership posture explicitly (the package never creates infrastructure and holds no `CreateTable`/`UpdateTable` permission at runtime, so the table lives in your IaC), then walks the full setup with copy-paste CLI: the base table, one-time TTL enablement (the package stamps `expireAt`, but only the table setting makes DynamoDB physically reap), vector index creation with the `SearchSchema` HASH element explained (the index partitions like the table, so tenant isolation holds inside search results, and a fresh index backfills before it is searchable), the S3 offload bucket with the lifecycle-rule backstop, and a complete least-privilege IAM policy.

The policy is derived from the code, not sketched: the package issues exactly `PutItem`, `GetItem`, `DeleteItem`, `Query`, `SearchVectors`, and the three S3 object actions -- no `DescribeTable`, no `Scan`, no wildcards. The index-creation shape is the one the live integration suite provisions against real DynamoDB.

**Package READMEs: the semantic search journey.** Python gains a full section (write with an embedding, recall by meaning, `pk` scoping, metadata filter, score direction per distance function, eventual consistency), bringing it to parity with TypeScript. The TypeScript section is retitled to "Semantic search", its main example no longer leads with the adapter, and the "Minimal IAM" note's pre-GA wording ("once that API is generally available") is replaced with the real `SearchVectors` statement. Both cross-link the root provisioning section.