### PR TITLE
Floor strands-agents at 1.48.0, where the Storage interface landed

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -12,7 +12,9 @@ license = "Apache-2.0"
 authors = [{ name = "Amazon Web Services" }]
 keywords = ["strands", "strands-agents", "dynamodb", "storage", "agent", "memory", "aws"]
 dependencies = [
-    "strands-agents",
+    # Floor: 1.48.0 introduced the unified Storage interface and StorageError
+    # (strands-agents/harness-sdk #3259). Below it, importing this package fails.
+    "strands-agents>=1.48.0",
     "boto3>=1.43.64",
 ]
 


### PR DESCRIPTION
`pyproject.toml` declared a bare `strands-agents` dependency, so pip could resolve any SDK version -- including ones predating the unified `Storage` interface this package implements. The failure mode would be an `ImportError` at first use instead of a clean resolver error at install time. The TypeScript package has carried the equivalent floor (`@strands-agents/sdk >=1.10.0`) since the import.

**The floor is measured, not guessed.** The interface landed upstream in strands-agents/harness-sdk#3259 (commit `1aff2707`); comparing that commit against release tags shows `python/v1.47.0` predates it and `python/v1.48.0` is the first release containing it. Verified empirically in both directions: the full unit suite passes on a venv pinned to `strands-agents==1.48.0` (53 passed), and on `1.47.0` the package fails exactly as an unfloored install would (`ImportError: cannot import name 'StorageError' from 'strands.types.exceptions'`).

Gates: ruff format + check, mypy --strict, 53 passed / 6 skipped.