### PR TITLE
Scope publish workflow working-directory to jobs that check out code

### DIFF
--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -12,10 +12,6 @@ on:
 permissions:
   contents: read
 
-defaults:
-  run:
-    working-directory: python
-
 jobs:
   check-tag:
     name: Check tag is python-v*
@@ -38,6 +34,9 @@ jobs:
     needs: check-tag
     if: needs.check-tag.outputs.should_publish == 'true'
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: python
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/publish-typescript.yml
+++ b/.github/workflows/publish-typescript.yml
@@ -11,10 +11,6 @@ on:
 permissions:
   contents: read
 
-defaults:
-  run:
-    working-directory: typescript
-
 jobs:
   check-tag:
     name: Check tag is typescript-v*
@@ -37,6 +33,9 @@ jobs:
     needs: check-tag
     if: needs.check-tag.outputs.should_publish == 'true'
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: typescript
     # Create an `npm` environment in repo settings to gate publishes behind
     # required reviewers. Publishing uses npm trusted publishing (OIDC): register
     # this repository + workflow + environment as a trusted publisher on the


### PR DESCRIPTION
The workflow-level `defaults.run.working-directory` applied to every job including `check-tag`, which runs on a bare runner with no checkout, so the directory does not exist and the first real release failed before doing anything. PR CI never executes release workflows, so the first tag was the first test. The default now lives on the jobs that check out code; `check-tag` needs no directory (it only inspects the tag name). Releases and tags will be recreated on the fixed commit, since release events read the workflow at the tag ref.