### PR TITLE
Bump TypeScript package to 0.1.1

### DIFF
--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "strands-dynamodb-storage",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "strands-dynamodb-storage",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@aws-sdk/client-dynamodb": "^3.1104.0",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,7 +1,7 @@
 {
   "name": "strands-dynamodb-storage",
-  "version": "0.1.0",
-  "description": "Amazon DynamoDB storage backend for the Strands Agents SDK — one Storage implementation for Session Manager, Memory Manager, and any subsystem, with optional S3 offload for large values and an optional native vector-search hook.",
+  "version": "0.1.1",
+  "description": "Amazon DynamoDB storage backend for the Strands Agents SDK \u2014 one Storage implementation for Session Manager, Memory Manager, and any subsystem, with optional S3 offload for large values and an optional native vector-search hook.",
   "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.js",


### PR DESCRIPTION
Patch release carrying the User-Agent attribution marker (#23) so npm-installed traffic is identifiable from the start of adoption. npm 0.1.0 shipped without the marker; releasing 0.1.1 immediately keeps the unmarked installed base at effectively zero. Python needs no release, its 0.1.0 already carries the marker.