### PR TITLE
docs: TTL/search interaction, conditional pk, and two example fixes

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -53,7 +53,7 @@ await store.delete("sessions/s1/snapshot.json")
 - Single-table design (`pk`/`sk`), with a structured `DynamoDBListQuery` extension point.
 - Optional Amazon S3 offload for values above the item-size limit (`s3_bucket=...`).
 - Optional gzip `compression="gzip"` (applied before the offload check).
-- Optional per-item TTL (`ttl_seconds=...`) with read/list expiry filtering.
+- Optional per-item TTL (`ttl_seconds=...`) with read/list expiry filtering (search does not filter; see below).
 - Native vector `search()` via Amazon DynamoDB vector indexes (`SearchVectors`,
   requires boto3 >= 1.43.64); a `vector_search` adapter can override the call.
 
@@ -65,6 +65,11 @@ vector index (no second vector store, no ETL), and because the index is partitio
 every search is scoped to the caller's key space -- one tenant's memories can never surface
 in another's results. Creating the table with a vector index (and the IAM permissions needed)
 is covered in the repository README's [Provisioning and permissions](../#provisioning-and-permissions).
+
+Two behaviours to know: `pk` is required whenever the index's `SearchSchema` declares a HASH
+element (the provisioning guide's setup does) and must be omitted when it doesn't. And because
+TTL deletion is asynchronous, `search()` can briefly return items whose expiry has passed but
+which DynamoDB has not yet physically deleted -- expiry filtering applies to `read`/`list` only.
 
 ```python
 from strands_dynamodb_storage import DynamoDBStorage, SearchQuery
@@ -83,7 +88,7 @@ await store.write(
 results = await store.search(SearchQuery(
     vector=embed("seating preferences?"),
     top_k=5,
-    pk="user/u1/memories",                # required: the index declares a HASH element
+    pk="user/u1",                         # the physical partition: the full key's first two segments
     filter={"kind": "preference"},        # optional metadata equality filter
     include_values=True,                  # hydrate each match's stored bytes
 ))

--- a/python/src/strands_dynamodb_storage/dynamodb_storage.py
+++ b/python/src/strands_dynamodb_storage/dynamodb_storage.py
@@ -63,7 +63,12 @@ class DynamoDBListQuery:
 
 @dataclass
 class SearchQuery:
-    """Vector similarity query for the optional native vector index."""
+    """Vector similarity query for the optional native vector index.
+
+    ``pk`` is required when the index's ``SearchSchema`` declares a HASH element
+    (the documented tenant-scoping setup does; the service rejects an unpinned
+    search against such an index) and must be omitted when it doesn't.
+    """
 
     vector: builtins.list[float]
     top_k: int
@@ -410,7 +415,10 @@ class DynamoDBStorage:
         depends on the index's distance function: for COSINE and EUCLIDEAN lower
         is closer; for DOT_PRODUCT higher is more similar. Results are returned
         in the service's most-similar-first order. Like a global secondary
-        index, the vector index is eventually consistent.
+        index, the vector index is eventually consistent. Unlike ``read``/``list``,
+        results are not filtered for TTL expiry: because TTL deletion is
+        asynchronous, a search can briefly return items whose expiry has passed
+        but which DynamoDB has not yet physically deleted.
 
         Raises:
             StorageError: If the search fails or ``top_k`` is out of range.

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -118,6 +118,8 @@ await store.write('sessions/tmp/x', data, { ttlSeconds: 3_600 })
 Stamps a DynamoDB-native epoch-seconds `expireAt` attribute (enable TTL on that attribute at the table level for physical
 cleanup). `read`/`list` also filter items whose expiry has passed, covering the lag before DynamoDB physically deletes
 them. With S3 offload, add an S3 lifecycle rule to reclaim offloaded objects (TTL removes only the DynamoDB pointer).
+Note that this filtering applies to `read`/`list` only: because TTL deletion is asynchronous, `search()` can briefly
+return items whose expiry has passed but which DynamoDB has not yet physically deleted.
 
 ## Semantic search — DynamoDB native vector index
 
@@ -150,7 +152,7 @@ const results = await store.search({
   vector: queryEmbedding,
   topK: 5,
   pk: 'memory/u1',          // required when the index declares a HASH element
-  filter: { kind: 'preference' },   // optional server-side metadata filter
+  filter: { kind: 'preference' },   // optional metadata equality filter (applied client-side)
   includeValues: true,      // hydrate each match's stored bytes
 })
 // results: Array<{ key: string; score: number; data?: Uint8Array; metadata?: Record<string, unknown> }>

--- a/typescript/src/dynamodb-storage.ts
+++ b/typescript/src/dynamodb-storage.ts
@@ -415,7 +415,10 @@ export class DynamoDBStorage implements Storage<string | DynamoDBListQuery> {
    * direction depends on the index's distance function: for COSINE and EUCLIDEAN
    * lower is closer; for DOT_PRODUCT higher is more similar. Results arrive in
    * the service's most-similar-first order. Like a global secondary index, the
-   * vector index is eventually consistent.
+   * vector index is eventually consistent. Unlike `read`/`list`, results are not
+   * filtered for TTL expiry: because TTL deletion is asynchronous, a search can
+   * briefly return items whose expiry has passed but which DynamoDB has not yet
+   * physically deleted.
    *
    * @throws {@link StorageError} if the search fails or `topK` is out of range
    */


### PR DESCRIPTION
### TTL and search
`read`/`list` filter items whose TTL has passed but which DynamoDB has not yet reaped; `search()` does not. Because TTL deletion is asynchronous, a search can briefly return items whose expiry has passed. Both READMEs and both `search()` doc blocks now say this explicitly instead of scoping the filtering promise implicitly.

### Conditional `pk`
`SearchQuery.pk` is required when the index's `SearchSchema` declares a HASH element (the service rejects an unpinned search with `SearchConditionExpression must be provided`) and must be omitted when it doesn't. The TypeScript TSDoc already said this; the Python docstring and both READMEs now match.

### Example fixes (found by running the examples against a live vector index)
- The Python semantic-search example passed `pk="user/u1/memories"`, but the physical partition is the full key's first two segments (`user/u1`), so the documented call silently returned zero results.
- The TypeScript example described the metadata filter as server-side; it is applied client-side after the search.

Docs and doc-comments only; no behavior change. Both language gates green.