### PR TITLE
fix: tolerate fractional TTL values on the shared table

### DIFF
--- a/python/src/strands_dynamodb_storage/dynamodb_storage.py
+++ b/python/src/strands_dynamodb_storage/dynamodb_storage.py
@@ -242,7 +242,9 @@ class DynamoDBStorage:
             extra[_META_ATTR] = _marshal_meta(metadata)
         effective_ttl = ttl_seconds if ttl_seconds is not None else self._ttl_seconds
         if self._ttl_enabled and effective_ttl is not None:
-            extra[self._ttl_attribute] = {"N": str(int(time.time()) + effective_ttl)}
+            # Floor the whole stamp: a float duration (e.g. 90.5) must not emit a
+            # fractional value that other readers of the shared table may not parse.
+            extra[self._ttl_attribute] = {"N": str(int(time.time() + effective_ttl))}
 
         payload = data
         compressed = False
@@ -522,9 +524,21 @@ class DynamoDBStorage:
         return "/".join(segments[:2]), ("/".join(segments[2:]) or _SENTINEL_SK)
 
     def _is_expired(self, item: dict[str, Any]) -> bool:
-        """True when the item's TTL attribute holds a past epoch-seconds value."""
+        """True when the item's TTL attribute holds a past epoch-seconds value.
+
+        Parses leniently: the table is shared infrastructure, and another producer
+        may stamp a fractional epoch value (``time.time()`` untruncated). DynamoDB's
+        reaper compares numerically, so a float is a valid TTL; a value this code
+        cannot parse is treated as not expired -- filtering is this method's job,
+        not validating other writers' data.
+        """
         raw = item.get(self._ttl_attribute, {}).get("N")
-        return raw is not None and int(raw) <= int(time.time())
+        if raw is None:
+            return False
+        try:
+            return float(raw) <= time.time()
+        except ValueError:
+            return False
 
     def _assert_pk_in_scope(self, pk: str) -> None:
         """Reject a caller-supplied partition key that falls outside this namespace.

--- a/python/tests/test_dynamodb_storage.py
+++ b/python/tests/test_dynamodb_storage.py
@@ -343,6 +343,57 @@ async def test_no_stamp_without_ttl_even_with_override(aws):
     assert "expireAt" not in raw_item(aws[0], "sessions/s1/a")
 
 
+async def test_float_ttl_duration_stamps_integer(aws):
+    """A fractional duration must floor to an integer stamp (type hints aren't enforced)."""
+    s = make(aws, ttl_seconds=3600)
+    await s.write("sessions/s1/a", b"v", ttl_seconds=90.5)  # type: ignore[arg-type]
+    raw = raw_item(aws[0], "sessions/s1/a")["expireAt"]["N"]
+    assert "." not in raw
+    assert int(raw) >= int(time.time()) + 90
+
+
+async def test_read_tolerates_foreign_float_ttl(aws):
+    """Another producer on the shared table may stamp a fractional epoch value.
+
+    An expired float filters like an expired int; a future float passes through;
+    neither crashes read().
+    """
+    ddb, _ = aws
+    s = make(aws, ttl_seconds=3600)
+    await s.write("sessions/s1/dead", b"D")
+    await s.write("sessions/s1/live", b"L")
+    for key, stamp in (("sessions/s1/dead", time.time() - 60.5), ("sessions/s1/live", time.time() + 3600.5)):
+        pk, sk = _split(key)
+        ddb.update_item(
+            TableName=TABLE,
+            Key={"pk": {"S": pk}, "sk": {"S": sk}},
+            UpdateExpression="SET expireAt = :v",
+            ExpressionAttributeValues={":v": {"N": str(stamp)}},
+        )
+    assert await s.read("sessions/s1/dead") is None
+    assert await s.read("sessions/s1/live") == b"L"
+
+
+async def test_read_ignores_wrong_type_ttl_attribute(aws):
+    """A TTL attribute of the wrong type is another writer's bug, not a read() crash.
+
+    DynamoDB's N type won't accept a non-numeric string, so the worst a foreign
+    writer can do beyond a float is stamp the attribute as a different type (S
+    here): the "N" lookup misses and the item is treated as not expired.
+    """
+    ddb, _ = aws
+    s = make(aws, ttl_seconds=3600)
+    await s.write("sessions/s1/a", b"v")
+    pk, sk = _split("sessions/s1/a")
+    ddb.update_item(
+        TableName=TABLE,
+        Key={"pk": {"S": pk}, "sk": {"S": sk}},
+        UpdateExpression="SET expireAt = :v",
+        ExpressionAttributeValues={":v": {"S": "not-a-number"}},
+    )
+    assert await s.read("sessions/s1/a") == b"v"
+
+
 # --------------------------------------------------------------------- namespace
 
 

--- a/typescript/src/dynamodb-storage.test.ts
+++ b/typescript/src/dynamodb-storage.test.ts
@@ -506,6 +506,15 @@ describe('DynamoDBStorage — TTL', () => {
     expect(item.expireAt).toBeUndefined()
   })
 
+  it('floors a fractional ttlSeconds to an integer stamp', async () => {
+    const { storage, client } = newStorage({ ttlSeconds: 3600 })
+    const before = Math.floor(Date.now() / 1000)
+    await storage.write('sessions/s1/a', bytes('v'), { ttlSeconds: 90.5 })
+    const item = [...client.items.values()][0]!
+    expect(Number.isInteger(item.expireAt)).toBe(true)
+    expect(item.expireAt).toBeGreaterThanOrEqual(before + 90)
+  })
+
   it('lets a per-write ttlSeconds override the instance default', async () => {
     const { storage, client } = newStorage({ ttlSeconds: 60 })
     const before = Math.floor(Date.now() / 1000)

--- a/typescript/src/dynamodb-storage.ts
+++ b/typescript/src/dynamodb-storage.ts
@@ -239,7 +239,8 @@ export class DynamoDBStorage implements Storage<string | DynamoDBListQuery> {
     if (options?.metadata) extra[META_ATTR] = options.metadata
     const ttlSeconds = options?.ttlSeconds ?? this._ttlSeconds
     if (this._ttlEnabled && ttlSeconds !== undefined) {
-      extra[this._ttlAttribute] = Math.floor(Date.now() / 1000) + ttlSeconds
+      // Floor the whole stamp so a fractional ttlSeconds can't emit a fractional value.
+      extra[this._ttlAttribute] = Math.floor(Date.now() / 1000 + ttlSeconds)
     }
     // Compress before the size check so compressible values can stay inline (and out
     // of S3). Keep the compressed form only when it actually shrinks, and record the


### PR DESCRIPTION
Two halves of one defect.

**Write side (both languages):** the stamp arithmetic let a fractional duration produce a fractional epoch value (Python type hints are not enforced at runtime; in TypeScript `Math.floor` applied only to the clock term, not the sum). The whole stamp is now floored.

**Read side (Python only):** `_is_expired` parsed the raw `N` string with `int()`, so an item stamped with a fractional epoch value by any other producer on the shared table crashed `read()` with a wrapped `ValueError`. DynamoDB's number type stores fractional values and its reaper compares numerically, so a float is a valid TTL. Parse with `float()` and treat a wrong-typed attribute as not expired: filtering is this path's job, not validating other writers' data. TypeScript reads the attribute as a number and needs no change here.

**Verification:** full gates green in both languages. The new regression tests were proven discriminating by running them against the pre-fix code: `test_float_ttl_duration_stamps_integer` and `test_read_tolerates_foreign_float_ttl` fail on `main`, as does the TypeScript `floors a fractional ttlSeconds` test.