### PR TITLE
fix: validate written vectors client-side, mirroring the query-side check

### DIFF
--- a/python/src/strands_dynamodb_storage/dynamodb_storage.py
+++ b/python/src/strands_dynamodb_storage/dynamodb_storage.py
@@ -237,6 +237,10 @@ class DynamoDBStorage:
         # The embedding stays inline even when the payload offloads, because the
         # native vector index can only index an on-item attribute.
         if vector is not None:
+            # Mirror of the query-side check in _native_vector_search: the service
+            # rejects non-finite values anyway, but as an opaque write failure.
+            if not all(math.isfinite(component) for component in vector):
+                raise StorageError("Vector contains non-finite values (nan/inf); the DynamoDB N type rejects them.")
             extra[self._vector_attribute] = {"L": [{"N": str(component)} for component in vector]}
         if metadata is not None:
             extra[_META_ATTR] = _marshal_meta(metadata)

--- a/python/tests/test_dynamodb_storage.py
+++ b/python/tests/test_dynamodb_storage.py
@@ -441,6 +441,16 @@ async def test_search_native_rejects_nonfinite_vector(aws):
         await storage.search(SearchQuery(vector=[float("nan"), 0.0], top_k=1))
 
 
+async def test_write_rejects_nonfinite_vector(aws):
+    """Mirror of the query-side check: same input, same clear client-side message."""
+    storage = make(aws)
+    for bad in (float("nan"), float("inf"), float("-inf")):
+        with pytest.raises(StorageError, match="non-finite"):
+            await storage.write("sessions/s1/m", b"v", vector=[bad, 0.0])
+    # and the item was never written
+    assert raw_item(aws[0], "sessions/s1/m") is None
+
+
 async def test_search_native_filter_overfetches_and_postfilters(aws):
     ddb, _ = aws
     storage = make(aws, prefix="tenant/a/")

--- a/typescript/src/dynamodb-storage.test.ts
+++ b/typescript/src/dynamodb-storage.test.ts
@@ -413,6 +413,14 @@ describe('DynamoDBStorage — vector search', () => {
     await expect(storage.search({ vector: [1, 0, 0], topK: 0 })).rejects.toThrow(/topK/)
   })
 
+  it('write rejects non-finite vectors with the same message as search', async () => {
+    const { storage, client } = newStorage()
+    for (const bad of [Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY]) {
+      await expect(storage.write('sessions/s1/m', bytes('v'), { vector: [bad, 0] })).rejects.toThrow(/non-finite/)
+    }
+    expect(client.items.size).toBe(0)
+  })
+
   it('native path rejects non-finite query vectors', async () => {
     const { storage } = newStorage()
     await expect(storage.search({ vector: [Number.NaN, 0], topK: 1 })).rejects.toThrow(/non-finite/)

--- a/typescript/src/dynamodb-storage.ts
+++ b/typescript/src/dynamodb-storage.ts
@@ -235,7 +235,14 @@ export class DynamoDBStorage implements Storage<string | DynamoDBListQuery> {
     const extra: Record<string, unknown> = {}
     // The embedding stays inline in DynamoDB even when the payload is offloaded,
     // because the native vector index can only index an on-item attribute.
-    if (options?.vector) extra[this._vectorAttribute] = options.vector
+    if (options?.vector) {
+      // Mirror of the query-side check in search(): the service rejects
+      // non-finite values anyway, but as an opaque write failure.
+      if (!options.vector.every((v) => Number.isFinite(v))) {
+        throw new StorageError('Vector contains non-finite values (nan/inf); the DynamoDB N type rejects them.')
+      }
+      extra[this._vectorAttribute] = options.vector
+    }
     if (options?.metadata) extra[META_ATTR] = options.metadata
     const ttlSeconds = options?.ttlSeconds ?? this._ttlSeconds
     if (this._ttlEnabled && ttlSeconds !== undefined) {


### PR DESCRIPTION
A non-finite component (`nan`/`inf`) in a written vector always fails at the service, since the DynamoDB `N` type rejects it, but surfaced as an opaque wrapped write error. The query path already catches the same input client-side with a clear message. This mirrors that check onto the write path in both languages: the same bad input now produces the same diagnosis, and the item is provably never written.

**Verification:** full gates green in both languages. Both new regression tests fail against the pre-fix code (the write previously succeeded under moto / the fake client, which do not model the service's `N`-type rejection).