### PR TITLE
fix: project only what search responses need, reuse the projected payload

### DIFF
--- a/python/src/strands_dynamodb_storage/dynamodb_storage.py
+++ b/python/src/strands_dynamodb_storage/dynamodb_storage.py
@@ -443,7 +443,10 @@ class DynamoDBStorage:
                     continue
                 data = None
                 if query.include_values:
-                    data = await self.read(key)
+                    # The native path decodes the projected payload into the match;
+                    # offloaded values, narrow projections, and adapter matches fall
+                    # back to a point read (which also fetches from S3 and decompresses).
+                    data = match["data"] if "data" in match else await self.read(key)
                 results.append(SearchResult(key=key, score=match["score"], data=data, metadata=match.get("metadata")))
             return results
         except StorageError:
@@ -474,15 +477,27 @@ class DynamoDBStorage:
         if query.filter is not None:
             top_k = min(query.top_k * _FILTER_OVERFETCH, _MAX_TOP_K)
 
+        # Project only what the response is for: keys (to rebuild the storage key)
+        # and metadata (results + client-side filter), adding the payload and its
+        # s3/gzip flags only when the caller asked for values. Everything else the
+        # index projects (ProjectionType ALL projects the whole item) is billed
+        # response bytes for data nobody reads. Every name is aliased: `data` is a
+        # DynamoDB reserved word.
+        names: dict[str, str] = {"#pk": _PK, "#sk": _SK, "#m": _META_ATTR}
+        projection = "#pk, #sk, #m"
+        if query.include_values:
+            names.update({"#d": _DATA_ATTR, "#s3": _S3_ATTR, "#z": _Z_ATTR})
+            projection += ", #d, #s3, #z"
         request: dict[str, Any] = {
             "TableName": self._table_name,
             "IndexName": self._index_name,
             "SearchVector": [{"N": str(v)} for v in query.vector],
             "TopK": top_k,
+            "ProjectionExpression": projection,
+            "ExpressionAttributeNames": names,
         }
         if query.pk is not None:
             request["SearchConditionExpression"] = "#pk = :pk"
-            request["ExpressionAttributeNames"] = {"#pk": _PK}
             request["ExpressionAttributeValues"] = {":pk": {"S": query.pk}}
 
         client = self._get_client()
@@ -500,6 +515,11 @@ class DynamoDBStorage:
             match: dict[str, Any] = {"key": full_key, "score": float(result["Score"])}
             if metadata is not None:
                 match["metadata"] = metadata
+            if query.include_values and not item.get(_S3_ATTR, {}).get("BOOL"):
+                blob = item.get(_DATA_ATTR, {}).get("B")
+                if blob is not None:
+                    raw = bytes(blob)
+                    match["data"] = gzip.decompress(raw) if item.get(_Z_ATTR, {}).get("BOOL") is True else raw
             matches.append(match)
             if len(matches) >= query.top_k:
                 break

--- a/python/tests/test_dynamodb_storage.py
+++ b/python/tests/test_dynamodb_storage.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import gzip
 import math
 import time
 from unittest import mock
@@ -471,6 +472,77 @@ async def test_search_native_filter_overfetches_and_postfilters(aws):
     # Over-fetched (top_k * factor, capped at 100), then post-filtered to top_k.
     assert sv.call_args.kwargs["TopK"] == 20
     assert [r.key for r in results] == ["m2", "m3"]
+
+
+async def test_search_native_projects_response_floor(aws):
+    """The request asks only for keys + metadata; payload attrs only with include_values."""
+    ddb, _ = aws
+    storage = make(aws)
+    resp = {"SearchResults": []}
+    with mock.patch.object(ddb, "search_vectors", create=True, return_value=resp) as sv:
+        await storage.search(SearchQuery(vector=[1.0], top_k=1, pk="tenant/a"))
+    req = sv.call_args.kwargs
+    assert req["ProjectionExpression"] == "#pk, #sk, #m"
+    assert req["ExpressionAttributeNames"] == {"#pk": "pk", "#sk": "sk", "#m": "meta"}
+    with mock.patch.object(ddb, "search_vectors", create=True, return_value=resp) as sv:
+        await storage.search(SearchQuery(vector=[1.0], top_k=1, pk="tenant/a", include_values=True))
+    req = sv.call_args.kwargs
+    assert req["ProjectionExpression"] == "#pk, #sk, #m, #d, #s3, #z"
+    assert req["ExpressionAttributeNames"]["#d"] == "data"
+
+
+async def test_search_include_values_reuses_projected_payload(aws):
+    """A projected inline payload is decoded from the hit; no GetItem is issued."""
+    ddb, _ = aws
+    storage = make(aws)
+    resp = {
+        "SearchResults": [
+            {
+                "Item": {
+                    "pk": {"S": "tenant/a"},
+                    "sk": {"S": "m1"},
+                    "data": {"B": b"inline payload"},
+                },
+                "Score": 0.1,
+            },
+            {
+                "Item": {
+                    "pk": {"S": "tenant/a"},
+                    "sk": {"S": "m2"},
+                    "data": {"B": gzip.compress(b"compressed payload")},
+                    "z": {"BOOL": True},
+                },
+                "Score": 0.2,
+            },
+        ]
+    }
+    with (
+        mock.patch.object(ddb, "search_vectors", create=True, return_value=resp),
+        mock.patch.object(ddb, "get_item", wraps=ddb.get_item) as gi,
+    ):
+        results = await storage.search(SearchQuery(vector=[1.0], top_k=2, pk="tenant/a", include_values=True))
+    assert [r.data for r in results] == [b"inline payload", b"compressed payload"]
+    assert gi.call_count == 0
+
+
+async def test_search_include_values_falls_back_for_offloaded(aws):
+    """An s3-flagged hit carries no inline payload; the point read fetches from S3."""
+    ddb, _ = aws
+    storage = make(aws, s3_bucket=BUCKET)
+    big = b"A" * 380_001
+    await storage.write("tenant/a/big", big, vector=[1.0])
+    resp = {
+        "SearchResults": [
+            {"Item": {"pk": {"S": "tenant/a"}, "sk": {"S": "big"}, "s3": {"BOOL": True}}, "Score": 0.1},
+        ]
+    }
+    with (
+        mock.patch.object(ddb, "search_vectors", create=True, return_value=resp),
+        mock.patch.object(ddb, "get_item", wraps=ddb.get_item) as gi,
+    ):
+        results = await storage.search(SearchQuery(vector=[1.0], top_k=1, pk="tenant/a", include_values=True))
+    assert results[0].data == big
+    assert gi.call_count == 1
 
 
 async def test_search_native_drops_foreign_namespace_matches(aws):

--- a/typescript/src/dynamodb-storage.test.ts
+++ b/typescript/src/dynamodb-storage.test.ts
@@ -45,9 +45,7 @@ class FakeDocumentClient {
           let projected = rest
           if (input.ProjectionExpression) {
             const wanted = new Set<string>(
-              input.ProjectionExpression.split(',').map(
-                (alias: string) => input.ExpressionAttributeNames[alias.trim()]
-              )
+              input.ProjectionExpression.split(',').map((alias: string) => input.ExpressionAttributeNames[alias.trim()])
             )
             projected = Object.fromEntries(Object.entries(rest).filter(([k]) => wanted.has(k)))
           }

--- a/typescript/src/dynamodb-storage.test.ts
+++ b/typescript/src/dynamodb-storage.test.ts
@@ -22,6 +22,8 @@ class FakeDocumentClient {
   }
   /** Captured input of the last SearchVectorsCommand, for request-shape assertions. */
   lastSearchVectorsInput: any = null
+  /** Number of GetCommand point reads issued, for read-avoidance assertions. */
+  getCalls = 0
   async send(command: any): Promise<any> {
     const input = command.input
     if (command instanceof SearchVectorsCommand) {
@@ -38,7 +40,18 @@ class FakeDocumentClient {
             Math.sqrt(v.reduce((a, x) => a + x * x, 0)) * Math.sqrt(queryVector.reduce((a, x) => a + x * x, 0))
           const cosineDistance = 1 - (norm === 0 ? 0 : dot / norm)
           const { vector: _v, ...rest } = item
-          return { Item: marshall(rest), Score: cosineDistance }
+          // Honor ProjectionExpression the way the service does: return only the
+          // projected attributes (all names are aliased through #placeholders).
+          let projected = rest
+          if (input.ProjectionExpression) {
+            const wanted = new Set<string>(
+              input.ProjectionExpression.split(',').map(
+                (alias: string) => input.ExpressionAttributeNames[alias.trim()]
+              )
+            )
+            projected = Object.fromEntries(Object.entries(rest).filter(([k]) => wanted.has(k)))
+          }
+          return { Item: marshall(projected), Score: cosineDistance }
         })
         .sort((a, b) => a.Score - b.Score)
         .slice(0, input.TopK)
@@ -51,6 +64,7 @@ class FakeDocumentClient {
       return input.ReturnValues === 'ALL_OLD' && old ? { Attributes: old } : {}
     }
     if (command instanceof GetCommand) {
+      this.getCalls += 1
       return { Item: this.items.get(this._k(input.Key.pk, input.Key.sk)) }
     }
     if (command instanceof DeleteCommand) {
@@ -379,6 +393,49 @@ describe('DynamoDBStorage — vector search', () => {
     const results = await storage.search({ vector: [1, 0, 0], topK: 2 })
     expect(results.map((r) => r.key)).toEqual(['memory/u1/a', 'memory/u1/b'])
     expect(results[0]!.score).toBeGreaterThanOrEqual(results[1]!.score)
+  })
+
+  it('projects the response floor: keys + metadata, payload attrs only with includeValues', async () => {
+    const { storage, client } = newStorage()
+    await storage.write('tenant/a/m1', bytes('v'), { vector: [1, 0, 0] })
+    await storage.search({ vector: [1, 0, 0], topK: 1 })
+    expect(client.lastSearchVectorsInput.ProjectionExpression).toBe('#pk, #sk, #m')
+    expect(client.lastSearchVectorsInput.ExpressionAttributeNames).toMatchObject({
+      '#pk': 'pk',
+      '#sk': 'sk',
+      '#m': 'meta',
+    })
+    await storage.search({ vector: [1, 0, 0], topK: 1, includeValues: true })
+    expect(client.lastSearchVectorsInput.ProjectionExpression).toBe('#pk, #sk, #m, #d, #s3, #z')
+  })
+
+  it('includeValues reuses the projected payload without a point read', async () => {
+    const { storage, client } = newStorage()
+    await storage.write('tenant/a/m1', bytes('inline payload'), { vector: [1, 0, 0] })
+    client.getCalls = 0
+    const results = await storage.search({ vector: [1, 0, 0], topK: 1, includeValues: true })
+    expect(new TextDecoder().decode(results[0]!.data!)).toBe('inline payload')
+    expect(client.getCalls).toBe(0)
+  })
+
+  it('includeValues decodes a gzip-compressed projected payload', async () => {
+    const { storage, client } = newStorage({ compression: 'gzip' })
+    const compressible = 'a'.repeat(2048)
+    await storage.write('tenant/a/m1', bytes(compressible), { vector: [1, 0, 0] })
+    client.getCalls = 0
+    const results = await storage.search({ vector: [1, 0, 0], topK: 1, includeValues: true })
+    expect(new TextDecoder().decode(results[0]!.data!)).toBe(compressible)
+    expect(client.getCalls).toBe(0)
+  })
+
+  it('includeValues falls back to a point read for an S3-offloaded payload', async () => {
+    const { storage, client } = newStorage({ s3: true })
+    const big = new Uint8Array(380_001).fill(65)
+    await storage.write('tenant/a/big', big, { vector: [1, 0, 0] })
+    client.getCalls = 0
+    const results = await storage.search({ vector: [1, 0, 0], topK: 1, includeValues: true })
+    expect(results[0]!.data!.byteLength).toBe(380_001)
+    expect(client.getCalls).toBe(1)
   })
 
   it('hydrates stored bytes when includeValues is set', async () => {

--- a/typescript/src/dynamodb-storage.ts
+++ b/typescript/src/dynamodb-storage.ts
@@ -422,7 +422,8 @@ export class DynamoDBStorage implements Storage<string | DynamoDBListQuery> {
   async search(query: SearchQuery): Promise<SearchResult[]> {
     if (query.pk !== undefined) this._assertPkInScope(query.pk)
     try {
-      const matches = this._vectorSearch
+      const matches: Array<{ key: string; score: number; metadata?: Record<string, unknown>; data?: Uint8Array }> = this
+        ._vectorSearch
         ? await this._vectorSearch({
             tableName: this._tableName,
             indexName: this._indexName,
@@ -443,7 +444,10 @@ export class DynamoDBStorage implements Storage<string | DynamoDBListQuery> {
         const result: SearchResult = { key, score: match.score }
         if (match.metadata !== undefined) result.metadata = match.metadata
         if (query.includeValues) {
-          const data = await this.read(key)
+          // The native path decodes the projected payload into the match; offloaded
+          // values, narrow projections, and adapter matches fall back to a point
+          // read (which also fetches from S3 and decompresses).
+          const data = match.data !== undefined ? match.data : await this.read(key)
           if (data) result.data = data
         }
         results.push(result)
@@ -467,7 +471,7 @@ export class DynamoDBStorage implements Storage<string | DynamoDBListQuery> {
    */
   private async _nativeVectorSearch(
     query: SearchQuery
-  ): Promise<Array<{ key: string; score: number; metadata?: Record<string, unknown> }>> {
+  ): Promise<Array<{ key: string; score: number; metadata?: Record<string, unknown>; data?: Uint8Array }>> {
     if (query.topK < 1 || query.topK > MAX_TOP_K) {
       throw new StorageError(`topK must be between 1 and ${MAX_TOP_K} (SearchVectors TopK limit); got ${query.topK}`)
     }
@@ -481,21 +485,34 @@ export class DynamoDBStorage implements Storage<string | DynamoDBListQuery> {
     const { SearchVectorsCommand } = await import('@aws-sdk/client-dynamodb')
     const { unmarshall } = await import('@aws-sdk/util-dynamodb')
     const client = await this._getClient()
+    // Project only what the response is for: keys (to rebuild the storage key)
+    // and metadata (results + client-side filter), adding the payload and its
+    // s3/gzip flags only when the caller asked for values. Everything else the
+    // index projects (ProjectionType ALL projects the whole item) is billed
+    // response bytes for data nobody reads. Every name is aliased: `data` is a
+    // DynamoDB reserved word.
+    const names: Record<string, string> = { '#pk': PK, '#sk': SK, '#m': META_ATTR }
+    let projection = '#pk, #sk, #m'
+    if (query.includeValues) {
+      Object.assign(names, { '#d': DATA_ATTR, '#s3': S3_ATTR, '#z': Z_ATTR })
+      projection += ', #d, #s3, #z'
+    }
     const response = await client.send(
       new SearchVectorsCommand({
         TableName: this._tableName,
         IndexName: this._indexName,
         SearchVector: query.vector.map((v) => ({ N: String(v) })),
         TopK: topK,
+        ProjectionExpression: projection,
+        ExpressionAttributeNames: names,
         ...(query.pk !== undefined && {
           SearchConditionExpression: '#pk = :pk',
-          ExpressionAttributeNames: { '#pk': PK },
           ExpressionAttributeValues: { ':pk': { S: query.pk } },
         }),
       })
     )
 
-    const matches: Array<{ key: string; score: number; metadata?: Record<string, unknown> }> = []
+    const matches: Array<{ key: string; score: number; metadata?: Record<string, unknown>; data?: Uint8Array }> = []
     for (const result of response.SearchResults ?? []) {
       if (!result.Item || result.Score === undefined) continue
       const item = unmarshall(result.Item)
@@ -504,7 +521,19 @@ export class DynamoDBStorage implements Storage<string | DynamoDBListQuery> {
       const fullKey = sk === '' || sk === '\u0000' ? pk : `${pk}/${sk}`
       const metadata = item[META_ATTR] as Record<string, unknown> | undefined
       if (query.filter !== undefined && !DynamoDBStorage._matchesSearchFilter(metadata, query.filter)) continue
-      matches.push({ key: fullKey, score: result.Score, ...(metadata !== undefined && { metadata }) })
+      const match: { key: string; score: number; metadata?: Record<string, unknown>; data?: Uint8Array } = {
+        key: fullKey,
+        score: result.Score,
+        ...(metadata !== undefined && { metadata }),
+      }
+      if (query.includeValues && item[S3_ATTR] !== true) {
+        const stored = item[DATA_ATTR] as Uint8Array | undefined
+        if (stored !== undefined) {
+          const raw = new Uint8Array(stored)
+          match.data = item[Z_ATTR] === true ? new Uint8Array(await gunzipAsync(raw)) : raw
+        }
+      }
+      matches.push(match)
       if (matches.length >= query.topK) break
     }
     return matches


### PR DESCRIPTION
Two halves of one mechanism on the native `SearchVectors` path.

**Projection:** the request now carries a `ProjectionExpression`. The floor is the key attributes (to rebuild the storage key) plus metadata (returned on results and needed for the client-side filter); the payload attribute and its s3/gzip flags are added only when `include_values` is set. Previously no projection was sent, so with the documented `ProjectionType: ALL` every hit returned the full stored item - payloads up to 380 KB included - as billed response bytes for data nobody read. All names are aliased (`data` is a DynamoDB reserved word).

**Payload reuse:** `include_values` previously issued one sequential `GetItem` per hit even though the payload had just arrived in the response. The native path now decodes the projected payload in place (including gzip), falling back to a point read only for S3-offloaded values, narrow index projections, and adapter matches - the read path also handles the S3 fetch and decompression.

**Verification:**
- Live against real DynamoDB and a real vector index, 10/10 checks: projection accepted in both forms, hits carry only the projected attributes, inline/gzip/offloaded payloads all return correct bytes with exactly one `GetItem` (the offloaded hit), and the metadata filter works over the projected response.
- Full gates green in both languages; the fake client now honors `ProjectionExpression`, and the new unit tests were proven discriminating by running them against the pre-fix code (3 fail on `main` in each language).