### PR TITLE
fix: honor trailing slash in string list prefixes

### DIFF
--- a/python/src/strands_dynamodb_storage/dynamodb_storage.py
+++ b/python/src/strands_dynamodb_storage/dynamodb_storage.py
@@ -623,7 +623,14 @@ class DynamoDBStorage:
             )
         pk = "/".join(segments[:2])
         sk_prefix = "/".join(segments[2:])
-        return await self._list_by_query(DynamoDBListQuery(pk=pk, sk_prefix=sk_prefix or None))
+        # Restore the trailing slash the segment split drops:
+        # 'a/b/turns/' must not match 'a/b/turnstile'.
+        if sk_prefix and full.endswith("/"):
+            sk_prefix += "/"
+        keys = await self._list_by_query(DynamoDBListQuery(pk=pk, sk_prefix=sk_prefix or None))
+        # begins_with on the sort key can't exclude the partition's sentinel row;
+        # enforce true string-prefix semantics on the full key.
+        return [key for key in keys if key.startswith(normalized)]
 
     async def _list_by_query(self, query: DynamoDBListQuery) -> builtins.list[str]:
         if query.sk_prefix is not None and query.sk_between is not None:

--- a/python/tests/test_dynamodb_storage.py
+++ b/python/tests/test_dynamodb_storage.py
@@ -162,6 +162,26 @@ async def test_list_structured_query_and_between_and_start_after(aws):
     assert await s.list(DynamoDBListQuery(pk=pk, start_after=f"{pk}/k/2")) == [f"{pk}/k/3", f"{pk}/k/4"]
 
 
+async def test_list_trailing_slash_excludes_sibling_keys(aws):
+    s = make(aws)
+    await s.write("sessions/s1/turns/1", b"a")
+    await s.write("sessions/s1/turnstile", b"b")  # sibling sharing the string prefix, not under 'turns/'
+    await s.write("sessions/s1/turns", b"c")
+    assert await s.list("sessions/s1/turns/") == ["sessions/s1/turns/1"]
+    assert await s.list("sessions/s1/turns") == [
+        "sessions/s1/turns",
+        "sessions/s1/turns/1",
+        "sessions/s1/turnstile",
+    ]
+
+
+async def test_list_trailing_slash_excludes_partition_sentinel_row(aws):
+    s = make(aws)
+    await s.write("sessions/s1", b"root")
+    await s.write("sessions/s1/a", b"a")
+    assert await s.list("sessions/s1/") == ["sessions/s1/a"]
+
+
 async def test_list_rejects_broad_prefix_and_dual_sk(aws):
     s = make(aws)
     with pytest.raises(StorageError, match="too broad"):

--- a/typescript/src/dynamodb-storage.test.ts
+++ b/typescript/src/dynamodb-storage.test.ts
@@ -268,6 +268,26 @@ describe('DynamoDBStorage — listing', () => {
     expect(keys).toEqual(['sessions/s1/k/2', 'sessions/s1/k/3'])
   })
 
+  it('a trailing slash in the prefix excludes sibling keys sharing the string prefix', async () => {
+    const { storage } = newStorage()
+    await storage.write('sessions/s1/turns/1', bytes('a'))
+    await storage.write('sessions/s1/turnstile', bytes('b')) // sibling sharing the string prefix, not under 'turns/'
+    await storage.write('sessions/s1/turns', bytes('c'))
+    expect(await storage.list('sessions/s1/turns/')).toEqual(['sessions/s1/turns/1'])
+    expect(await storage.list('sessions/s1/turns')).toEqual([
+      'sessions/s1/turns',
+      'sessions/s1/turns/1',
+      'sessions/s1/turnstile',
+    ])
+  })
+
+  it('a trailing slash in the prefix excludes the partition sentinel row', async () => {
+    const { storage } = newStorage()
+    await storage.write('sessions/s1', bytes('root'))
+    await storage.write('sessions/s1/a', bytes('a'))
+    expect(await storage.list('sessions/s1/')).toEqual(['sessions/s1/a'])
+  })
+
   it('rejects a too-broad string prefix that cannot resolve a partition', async () => {
     const { storage } = newStorage()
     await expect(storage.list('sessions/')).rejects.toThrow(/too broad/)

--- a/typescript/src/dynamodb-storage.ts
+++ b/typescript/src/dynamodb-storage.ts
@@ -630,8 +630,14 @@ export class DynamoDBStorage implements Storage<string | DynamoDBListQuery> {
       )
     }
     const pk = segments.slice(0, 2).join('/')
-    const skPrefix = segments.slice(2).join('/')
-    return this._listByQuery(skPrefix ? { pk, skPrefix } : { pk })
+    let skPrefix = segments.slice(2).join('/')
+    // Restore the trailing slash the segment split drops:
+    // 'a/b/turns/' must not match 'a/b/turnstile'.
+    if (skPrefix && full.endsWith('/')) skPrefix += '/'
+    const keys = await this._listByQuery(skPrefix ? { pk, skPrefix } : { pk })
+    // begins_with on the sort key can't exclude the partition's sentinel row;
+    // enforce true string-prefix semantics on the full key.
+    return keys.filter((key) => key.startsWith(normalized))
   }
 
   private async _listByQuery(query: DynamoDBListQuery): Promise<string[]> {


### PR DESCRIPTION
*Issue #, if available:*

/

*Description of changes:*

Found a bug in `list()` with string prefixes: a trailing slash gets lost, so the listing can return keys that don't actually match the prefix.

The prefix is split on `/` to build the partition query, and that split throws away the trailing slash (even though `normalizePrefix` explicitly keeps it because it matters for matching). Example with these keys:

```
sessions/s1/turns/1
sessions/s1/turnstile
sessions/s1/turns
```

`list("sessions/s1/turns/")` ends up running `begins_with(sk, "turns")` instead of `begins_with(sk, "turns/")`, so all three come back. Only the first one really starts with the prefix. There's also a smaller edge case: `list("sessions/s1/")` returns the key `sessions/s1` itself, since that item lives in the same partition and a sort key condition can't filter it out.

The fix:
- keep the trailing slash to the sort key prefix so the query becomes `begins_with(sk, "turns/")` and DynamoDB already excludes turnstile and turns
- filter the results with `key.startswith(prefix)` as a final check, which also handles the `sessions/s1` edge case

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
