### PR TITLE
docs: add examples/session-resume

### DIFF
--- a/examples/session-resume/README.md
+++ b/examples/session-resume/README.md
@@ -1,0 +1,77 @@
+# Resume a session after a restart
+
+An agent holds its conversation in process memory, so a deploy, a crash, or a
+Lambda environment being recycled ends the conversation. This example persists
+the agent's state to an Amazon DynamoDB table through
+`SnapshotSessionManager`, so a brand-new process picks up exactly where the
+last one stopped.
+
+## How it works
+
+`SnapshotSessionManager` snapshots the agent after each invocation and writes
+the snapshot through the `Storage` contract. Handing it a `DynamoDBStorage`
+makes DynamoDB the backend, and the manager namespaces everything it writes
+under `session/<session_id>/`, so one table serves any number of sessions:
+
+```python
+storage = DynamoDBStorage("agent-storage", region_name="us-east-1")
+session = SnapshotSessionManager("session-resume-demo", storage=storage)
+agent = Agent(session_manager=session)
+```
+
+On construction, the manager looks for the latest snapshot under the session
+id and restores it if present. That is the whole resume mechanism: there is no
+separate restore call, and no difference between the code for the first run
+and the hundredth.
+
+## Run it
+
+Create the table (once) and provide credentials that can reach it and invoke
+your Bedrock model:
+
+```bash
+aws dynamodb create-table \
+  --table-name agent-storage \
+  --attribute-definitions AttributeName=pk,AttributeType=S AttributeName=sk,AttributeType=S \
+  --key-schema AttributeName=pk,KeyType=HASH AttributeName=sk,KeyType=RANGE \
+  --billing-mode PAY_PER_REQUEST
+
+pip install strands-agents strands-dynamodb-storage
+```
+
+Tell the agent something, then exit the process:
+
+```bash
+python session_resume.py --table agent-storage tell \
+  "My rental car is a blue Nissan Micra, parked in bay 42"
+```
+
+Ask about it from a completely new process:
+
+```bash
+python session_resume.py --table agent-storage ask \
+  "What car am I driving and where is it parked?"
+```
+
+```text
+Based on what you just told me, you are driving a blue Nissan Micra,
+parked in bay 42.
+```
+
+The second process started with nothing in memory. The answer came from the
+snapshot in DynamoDB.
+
+## Why DynamoDB here
+
+Session state sits on the hot path of every agent turn: it is loaded before
+each model call. DynamoDB point reads keep that load at single-digit
+milliseconds, on-demand capacity absorbs a fleet of sessions going from idle
+to thousands of concurrent invocations, and the HTTP data plane needs no
+connection pool, which matters on AWS Lambda and Amazon Bedrock AgentCore
+Runtime where the process serving a session changes constantly.
+
+## Clean up
+
+```bash
+aws dynamodb delete-table --table-name agent-storage
+```

--- a/examples/session-resume/session_resume.py
+++ b/examples/session-resume/session_resume.py
@@ -1,0 +1,52 @@
+"""Resume a conversation after a restart, with session state in Amazon DynamoDB.
+
+Run 1 tells the agent a fact and exits, taking the process (and all in-memory
+state) with it. Run 2 constructs a brand-new agent with the same session id and
+asks about the fact. The answer comes from the snapshot that
+``SnapshotSessionManager`` persisted to DynamoDB, not from anything held in
+memory.
+
+Prerequisites:
+  - A DynamoDB table with string keys ``pk`` / ``sk`` (see README.md).
+  - AWS credentials with PutItem/GetItem/DeleteItem/Query on the table and
+    InvokeModel on your Bedrock model.
+
+Usage:
+  python session_resume.py --table agent-storage tell "My rental car is a blue Nissan Micra"
+  python session_resume.py --table agent-storage ask "What car am I driving?"
+"""
+
+import argparse
+
+from strands import Agent
+from strands.session import SnapshotSessionManager
+from strands_dynamodb_storage import DynamoDBStorage
+
+SESSION_ID = "session-resume-demo"
+
+
+def build_agent(table: str, region: str) -> Agent:
+    """Construct an agent whose session state lives in DynamoDB.
+
+    A new process starts with no in-memory state; if a snapshot for
+    SESSION_ID exists in the table, the session manager restores it here.
+    """
+    storage = DynamoDBStorage(table, region_name=region)
+    session = SnapshotSessionManager(SESSION_ID, storage=storage)
+    return Agent(session_manager=session)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--table", default="agent-storage")
+    parser.add_argument("--region", default="us-east-1")
+    parser.add_argument("verb", choices=["tell", "ask"])
+    parser.add_argument("message")
+    args = parser.parse_args()
+
+    agent = build_agent(args.table, args.region)
+    agent(args.message)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
First entry in an `examples/` library for the repo. Each example is a self-contained directory with a walkthrough README and a runnable script, verified against real DynamoDB before submission.

## What it shows

Conversation resume across process restarts: `SnapshotSessionManager` backed by `DynamoDBStorage`. Run 1 tells the agent a fact and the process exits; run 2 is a brand-new process with the same session id and answers from the snapshot persisted in the table.

## Verification

- Executed end to end against a live us-east-1 table: the fresh process correctly recalled the fact stored by the previous one.
- `ruff check --select E,F,I,B --line-length 120` and `mypy --python-version 3.10` clean (matches the package CI configuration).

## Notes

- Placed at the repo root under `examples/` (language-neutral home; TypeScript mirrors can join later). CI path filters (`python/**`, `typescript/**`) are unaffected.
- Follow-up PRs add: semantic memory (MemoryManager bridge), multi-tenant scoping, TTL sessions, S3 context offload, and a customer-support capstone. One PR per example so each reviews independently.