### PR TITLE
docs: add examples/semantic-memory

### DIFF
--- a/examples/semantic-memory/README.md
+++ b/examples/semantic-memory/README.md
@@ -1,0 +1,97 @@
+# Semantic long-term memory
+
+Session persistence gets a conversation through a restart. The harder problem
+is recalling something a user said weeks ago, in a new conversation that
+shares no keys or words with the old one. This example gives a Strands agent
+that recall using a DynamoDB vector index on the same table that holds the
+rest of its state: memories are embedded on write, and recalled by meaning at
+question time.
+
+## How it works
+
+The package ships the storage contract and vector search
+(`write(vector=...)` and `search(SearchQuery)`); the Strands SDK's Memory
+Manager consumes anything implementing its `MemoryStore` protocol. The bridge
+between them is a small class you define in your own application, included
+here as `DynamoDBMemoryStore`:
+
+- `add()` embeds the content (Amazon Titan Text Embeddings V2, 1024
+  dimensions) and writes bytes + vector + metadata in one call.
+- `search()` embeds the query and runs a vector index search scoped to the
+  user's partition, returning `MemoryEntry` values.
+
+Wiring it into the agent is one constructor argument:
+
+```python
+memory = MemoryManager(stores=[DynamoDBMemoryStore(storage, partition="user/u1", embed=embed)],
+                       add_tool_config=True)
+agent = Agent(memory_manager=memory)
+```
+
+The Memory Manager retrieves relevant entries before each model call and folds
+them into the model input, and `add_tool_config=True` registers an
+`add_memory` tool so the model can store new facts through the same table it
+recalls from.
+
+Notice the `pk` argument in `search()`. The vector index is partitioned the
+same way the table is, so every search is scoped to one partition: a user's
+search never ranges over another user's memories. The partition value is
+supplied by the caller, so this is query scoping rather than an authorization
+boundary; access control belongs in AWS IAM and your application layer.
+
+## Run it
+
+Create a table with a vector index sized to the embedding model (once):
+
+```bash
+aws dynamodb create-table \
+  --table-name agent-storage \
+  --attribute-definitions AttributeName=pk,AttributeType=S AttributeName=sk,AttributeType=S \
+  --key-schema AttributeName=pk,KeyType=HASH AttributeName=sk,KeyType=RANGE \
+  --billing-mode PAY_PER_REQUEST \
+  --vector-indexes '[{
+    "IndexName": "vector_index",
+    "VectorAttribute": {"AttributeName": "vector"},
+    "SearchSchema": [{"AttributeName": "pk", "SearchSchemaElementType": "HASH"}],
+    "Projection": {"ProjectionType": "ALL"},
+    "Dimensions": 1024,
+    "DistanceFunction": "COSINE"
+  }]'
+
+pip install strands-agents strands-dynamodb-storage
+```
+
+Wait for the index to show `IndexStatus: ACTIVE` with `Backfilling` false in
+`describe-table`, then seed three memories and ask:
+
+```bash
+python semantic_memory.py --table agent-storage seed
+python semantic_memory.py --table agent-storage ask \
+  "Book me a flight seat for my December trip. Which seat should I pick?"
+```
+
+```text
+Tool #1: search_memory
+Based on your saved preferences and trip details, here's what I found:
+Trip: Tokyo in December
+Seat Preference: You prefer window seats on long flights
+...
+You have a peanut allergy — make sure to flag that when booking your meal!
+```
+
+The question shares almost no words with the stored memories. All three
+reached the model by meaning, retrieved from DynamoDB before the model call.
+
+## Why DynamoDB here
+
+The vector index lives on the same table as the agent's sessions and state,
+so there is no separate vector database to provision, no pipeline copying
+data into it, and no reconciliation job when the two disagree. Vector indexes
+are eventually consistent (the same model as a global secondary index), so a
+memory written moments ago may take a short time to become searchable.
+
+## Clean up
+
+```bash
+aws dynamodb delete-table --table-name agent-storage
+```

--- a/examples/semantic-memory/semantic_memory.py
+++ b/examples/semantic-memory/semantic_memory.py
@@ -1,0 +1,132 @@
+"""Give an agent long-term memory it can search by meaning, on one DynamoDB table.
+
+Session persistence gets a conversation through a restart. This example covers
+the other half: recalling something a user said weeks ago, in a new
+conversation that shares no keys or words with the old one. Memories are
+embedded on write, stored with a vector alongside the bytes, and recalled with
+a DynamoDB vector index search scoped to the user's partition.
+
+The ``DynamoDBMemoryStore`` class here is application code: the package ships
+the storage contract and vector search, and this bridge adapts them to the
+Strands SDK's ``MemoryStore`` protocol so the Memory Manager can pull relevant
+memories into the model input before each call.
+
+Prerequisites:
+  - A DynamoDB table with a vector index (see README.md; 1024 dims, COSINE).
+  - Credentials for the table, dynamodb:SearchVectors, and Bedrock InvokeModel
+    (agent model + amazon.titan-embed-text-v2:0 for embeddings).
+
+Usage:
+  python semantic_memory.py --table agent-storage seed
+  python semantic_memory.py --table agent-storage ask \
+      "Book me a flight seat for my December trip. Which seat should I pick?"
+"""
+
+import argparse
+import asyncio
+import json
+import uuid
+from typing import Any, Optional
+
+import boto3
+from strands import Agent
+from strands.memory import MemoryEntry, MemoryManager
+from strands.memory.types import Metadata, SearchOptions
+from strands_dynamodb_storage import DynamoDBStorage, SearchQuery
+
+USER_PARTITION = "user/u1"
+
+SEED_MEMORIES = [
+    "Prefers window seats on long flights",
+    "Planning a trip to Tokyo in December",
+    "Has a peanut allergy, flag it when booking meals",
+]
+
+
+def make_embedder(region: str) -> Any:
+    """Return an embed(text) -> list[float] callable backed by Titan V2 (1024 dims)."""
+    bedrock = boto3.client("bedrock-runtime", region_name=region)
+
+    def embed(text: str) -> list[float]:
+        response = bedrock.invoke_model(
+            modelId="amazon.titan-embed-text-v2:0",
+            body=json.dumps({"inputText": text, "dimensions": 1024}),
+        )
+        return json.loads(response["body"].read())["embedding"]  # type: ignore[no-any-return]
+
+    return embed
+
+
+class DynamoDBMemoryStore:
+    """Adapts DynamoDBStorage vector search to the Strands MemoryStore protocol."""
+
+    def __init__(self, storage: DynamoDBStorage, partition: str, embed: Any) -> None:
+        self.storage = storage
+        self.partition = partition
+        self.embed = embed
+        self.name = "dynamodb"
+        self.description = "Long-term memories in DynamoDB, searched by meaning"
+        self.max_search_results = 3
+        self.writable = True
+        self.extraction = None
+
+    async def add(self, content: str, metadata: Optional[Metadata] = None) -> None:
+        await self.storage.write(
+            f"memories/{uuid.uuid4().hex[:8]}",
+            content.encode(),
+            vector=self.embed(content),
+            metadata=metadata,
+        )
+
+    async def search(self, query: str, options: Optional[SearchOptions] = None) -> list[MemoryEntry]:
+        results = await self.storage.search(
+            SearchQuery(
+                vector=self.embed(query),
+                top_k=self.max_search_results,
+                pk=self.partition,
+                include_values=True,
+            )
+        )
+        return [
+            MemoryEntry(content=r.data.decode(), metadata=r.metadata)
+            for r in results
+            if r.data is not None
+        ]
+
+
+def build_store(table: str, region: str) -> DynamoDBMemoryStore:
+    storage = DynamoDBStorage(table, region_name=region, prefix=USER_PARTITION)
+    return DynamoDBMemoryStore(storage, partition=USER_PARTITION, embed=make_embedder(region))
+
+
+async def seed(store: DynamoDBMemoryStore) -> None:
+    for memory in SEED_MEMORIES:
+        await store.add(memory, metadata={"kind": "preference"})
+        print(f"stored: {memory}")
+
+
+def ask(store: DynamoDBMemoryStore, question: str) -> None:
+    # MemoryStore's optional methods (add_messages, initialize, get_tools) are
+    # detected at runtime by the manager, but mypy requires them structurally.
+    memory = MemoryManager(stores=[store], add_tool_config=True)  # type: ignore[list-item]
+    agent = Agent(memory_manager=memory)
+    agent(question)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--table", default="agent-storage")
+    parser.add_argument("--region", default="us-east-1")
+    parser.add_argument("verb", choices=["seed", "ask"])
+    parser.add_argument("question", nargs="?", default="Which seat should I pick for my December trip?")
+    args = parser.parse_args()
+
+    store = build_store(args.table, args.region)
+    if args.verb == "seed":
+        asyncio.run(seed(store))
+    else:
+        ask(store, args.question)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Second entry in the examples library (follows #32). Self-contained directory: walkthrough README + runnable script, verified against real DynamoDB before submission.

## What it shows

Long-term memory searched by meaning, on a DynamoDB vector index living on the same table as the agent state. Ships the `DynamoDBMemoryStore` bridge class (application code adapting `DynamoDBStorage` + `SearchQuery` to the SDK `MemoryStore` protocol), Titan V2 embeddings, `MemoryManager` injection before each model call, and the `add_memory` tool.

The README calls out the `pk` scoping semantics explicitly: query scoping via the search schema HASH element, not an authorization boundary.

## Verification

- Live us-east-1 vector-indexed table: seeded 3 memories, a fresh process recalled all three by meaning (window-seat preference, Tokyo December trip, peanut allergy) for a question sharing almost no words with the stored text, via the `search_memory` tool path.
- Ruff (E,F,I,B, 120) and mypy 3.10 clean.

## Note on typing

The bridge is a plain class with one documented `type: ignore[list-item]` at the `stores=` call site: the SDK MemoryStore protocol declares optional methods (`add_messages`, `initialize`, `get_tools`) that mypy requires structurally — the SDK own vended `TestMemoryStore` trips the identical abstract-instantiation error. Worth an upstream issue on strands-agents.

Independent of #32; no shared files.