### PR TITLE
docs: add examples/multi-tenant

### DIFF
--- a/examples/multi-tenant/README.md
+++ b/examples/multi-tenant/README.md
@@ -1,0 +1,79 @@
+# Multi-tenant isolation on one table
+
+An agent platform serving many users has to keep one user's memories out of
+another user's results. This example shows that with
+strands-dynamodb-storage that is a schema decision made once, at construction
+time, rather than a filter you have to remember on every query.
+
+## How it works
+
+Two mechanisms, both set once:
+
+**The constructor prefix scopes the byte contract.** A store built with
+`prefix="user/alice"` pins every `write`, `read`, `delete`, and `list` inside
+Alice's key space. Two tenants using the same logical key `memories/m1`
+resolve to physically distinct partitions:
+
+```python
+alice = DynamoDBStorage(table, prefix="user/alice")
+bob = DynamoDBStorage(table, prefix="user/bob")
+```
+
+**The search schema scopes the vector index.** The index is partitioned by
+`pk` (its search schema HASH element), and every search supplies one
+partition. A search scoped to Alice's partition never ranges over Bob's
+vectors, no matter how similar the content is:
+
+```python
+results = await alice.search(SearchQuery(vector=embed(q), top_k=5, pk="user/alice"))
+```
+
+The script seeds each user with a near-identical coffee-preference memory
+under the same logical key, then proves both boundaries: each tenant's
+`list()` sees only its own key, and each tenant's semantic search returns only
+its own memory, with `top_k=5` leaving the other tenant's vector unreachable
+rather than merely outranked.
+
+## Run it
+
+Provision the vector-indexed table from the
+[semantic-memory example](../semantic-memory/README.md#run-it), then:
+
+```bash
+pip install strands-dynamodb-storage boto3
+python multi_tenant.py --table agent-storage
+```
+
+```text
+seeded one coffee memory per user (same logical key memories/m1)
+
+alice.list('memories/') -> ['memories/m1']
+bob.list('memories/')   -> ['memories/m1']
+
+search as alice: ['Alice drinks oat-milk lattes, decaf after noon']
+  Bob's memory in alice's results: False
+search as bob: ['Bob drinks double espressos, no milk ever']
+  Alice's memory in bob's results: False
+```
+
+The vector index is eventually consistent, so a memory written moments before
+the search may take a short time to become searchable; the script writes and
+searches back to back, and a rerun covers any lag.
+
+## Scoping is not authorization
+
+The partition value is supplied by the caller: a principal holding
+`dynamodb:SearchVectors` on the table can search any partition. This
+mechanism guarantees that well-behaved application code cannot accidentally
+cross tenants; keeping a hostile caller out belongs to AWS IAM and your
+application layer. The work each search performs also tracks the size of one
+tenant's partition rather than the whole table, so a busy tenant does not
+make every other tenant's recall slower or more expensive.
+
+## Clean up
+
+The script deletes its own demo items. Drop the table when finished:
+
+```bash
+aws dynamodb delete-table --table-name agent-storage
+```

--- a/examples/multi-tenant/multi_tenant.py
+++ b/examples/multi-tenant/multi_tenant.py
@@ -1,0 +1,96 @@
+"""Serve many tenants from one DynamoDB table, with per-tenant isolation.
+
+A memory store serving many users has to keep one user's memories out of
+another user's results. With this package that is a schema decision made at
+construction time, not a filter appended to every query:
+
+- The constructor ``prefix`` pins every write, read, and listing inside the
+  tenant's own key space, so two tenants resolve the same logical key to
+  physically distinct partitions.
+- The vector index is partitioned by ``pk`` (its search schema HASH element),
+  so a search scoped to one tenant's partition never ranges over another
+  tenant's vectors, no matter how similar they are.
+
+This script seeds two users with near-identical memories, then shows that
+listings and semantic searches for one user never surface the other's data,
+even when the other user's memory is the closest match in the whole table.
+
+Prerequisites: vector-indexed table (see README.md), Bedrock access for
+Titan embeddings.
+
+Usage:
+  python multi_tenant.py --table agent-storage
+"""
+
+import argparse
+import asyncio
+import json
+from typing import Any
+
+import boto3
+from strands_dynamodb_storage import DynamoDBStorage, SearchQuery
+
+ALICE = "user/alice"
+BOB = "user/bob"
+
+
+def make_embedder(region: str) -> Any:
+    bedrock = boto3.client("bedrock-runtime", region_name=region)
+
+    def embed(text: str) -> list[float]:
+        response = bedrock.invoke_model(
+            modelId="amazon.titan-embed-text-v2:0",
+            body=json.dumps({"inputText": text, "dimensions": 1024}),
+        )
+        return json.loads(response["body"].read())["embedding"]  # type: ignore[no-any-return]
+
+    return embed
+
+
+async def main_async(table: str, region: str) -> None:
+    embed = make_embedder(region)
+
+    # One store per tenant. Same table, same code path; only the prefix differs.
+    alice = DynamoDBStorage(table, region_name=region, prefix=ALICE)
+    bob = DynamoDBStorage(table, region_name=region, prefix=BOB)
+
+    # Near-identical content on both sides. If scoping leaked, Bob's espresso
+    # memory would be the nearest neighbor for Alice's coffee question.
+    await alice.write("memories/m1", b"Alice drinks oat-milk lattes, decaf after noon",
+                      vector=embed("Alice drinks oat-milk lattes, decaf after noon"))
+    await bob.write("memories/m1", b"Bob drinks double espressos, no milk ever",
+                    vector=embed("Bob drinks double espressos, no milk ever"))
+    print("seeded one coffee memory per user (same logical key memories/m1)\n")
+
+    # 1. The byte contract is scoped: each tenant lists only its own keys.
+    print(f"alice.list('memories/') -> {await alice.list('memories/')}")
+    print(f"bob.list('memories/')   -> {await bob.list('memories/')}\n")
+
+    # 2. Search is scoped by partition: each tenant's query is answered only
+    #    from that tenant's vectors.
+    question = "how does this user take their coffee?"
+    for name, store, pk in (("alice", alice, ALICE), ("bob", bob, BOB)):
+        results = await store.search(SearchQuery(vector=embed(question), top_k=5, pk=pk, include_values=True))
+        answers = [r.data.decode() for r in results if r.data is not None]
+        print(f"search as {name}: {answers}")
+        other = "Bob" if name == "alice" else "Alice"
+        leaked = any(other in a for a in answers)
+        print(f"  {other}'s memory in {name}'s results: {leaked}")
+        assert not leaked, "cross-tenant leak"
+
+    # Clean up the demo items.
+    await alice.delete("memories/m1")
+    await bob.delete("memories/m1")
+    print("\ndemo items deleted")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--table", default="agent-storage")
+    parser.add_argument("--region", default="us-east-1")
+    args = parser.parse_args()
+    asyncio.run(main_async(args.table, args.region))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Third entry in the examples library (follows #32, #33). Self-contained: walkthrough README + runnable script, verified against real DynamoDB before submission.

## What it shows

Per-tenant isolation on one table as a schema decision made once at construction, not a per-query filter: the constructor `prefix` scoping the byte contract, and the search schema HASH element scoping the vector index.

The script is deterministic (no agent loop): it seeds two users with near-identical coffee memories under the same logical key `memories/m1`, then asserts that each tenant lists only its own key and each semantic search returns only that tenant memory — with `top_k=5`, so the other tenant vector would surface if it were reachable at all.

The README states plainly that this is query scoping rather than an authorization boundary, and that keeping a hostile caller out belongs to IAM and the application layer.

## Verification

- Live us-east-1 vector-indexed table: both isolation assertions passed (no cross-tenant rows in list or search, both directions). Script deletes its own demo items.
- Ruff (E,F,I,B, 120) and mypy 3.10 clean.

Independent of #32/#33; no shared files.