### PR TITLE
docs: add examples/ttl-sessions

### DIFF
--- a/examples/ttl-sessions/README.md
+++ b/examples/ttl-sessions/README.md
@@ -1,0 +1,78 @@
+# Self-expiring sessions with TTL
+
+Ephemeral state accumulates fast in agent systems: anonymous visitor
+sessions, tool scratch space, verification codes. Without a retention
+mechanism someone ends up writing a cleanup job. This example makes retention
+a constructor argument instead, using DynamoDB-native TTL.
+
+## How it works
+
+Constructing the store with `ttl_seconds` opts it in to TTL:
+
+```python
+ephemeral = DynamoDBStorage(table, prefix="guest/g1", ttl_seconds=3600)
+```
+
+Three things follow:
+
+- **Every write stamps** an epoch-seconds `expireAt` attribute (a per-write
+  `ttl_seconds` can override the default).
+- **Reads and listings filter** items whose expiry has already passed, so
+  expired data is gone from the application's view immediately.
+- **DynamoDB physically reaps** expired items in the background, at no
+  request cost, typically within a few days.
+
+The read-time filter is the part that matters for correctness: the reaper's
+timing is not a contract, so the package never trusts it. The script makes
+this visible by peeking underneath with a raw `GetItem` after expiry: the
+item is still physically there, while `read` and `list` already report it
+gone.
+
+Stores with and without TTL coexist on one table: the script writes an
+ephemeral cart session and a durable consent record under the same tenant
+prefix, and only the cart expires.
+
+## Run it
+
+Create the table and enable TTL on the package's expiry attribute (once):
+
+```bash
+aws dynamodb create-table \
+  --table-name agent-storage \
+  --attribute-definitions AttributeName=pk,AttributeType=S AttributeName=sk,AttributeType=S \
+  --key-schema AttributeName=pk,KeyType=HASH AttributeName=sk,KeyType=RANGE \
+  --billing-mode PAY_PER_REQUEST
+
+aws dynamodb update-time-to-live \
+  --table-name agent-storage \
+  --time-to-live-specification "Enabled=true, AttributeName=expireAt"
+
+pip install strands-dynamodb-storage boto3
+python ttl_sessions.py --table agent-storage
+```
+
+```text
+wrote session/cart with ttl_seconds=8, profile/consent with no TTL
+before expiry: read session/cart -> b'3 items, checkout not started'
+before expiry: list ->  ['profile/consent', 'session/cart']
+
+waiting 10s for expiry...
+after expiry: read session/cart -> None
+after expiry: list session/ -> []
+after expiry: read profile/consent -> b'cookie banner accepted v3'
+raw GetItem still returns an item: True (reaper removes it in the background)
+```
+
+## Considerations
+
+- TTL filtering applies to `read` and `list`. `search()` can briefly return
+  an expired item that DynamoDB has not yet physically removed.
+- If you combine TTL with S3 offload, add an S3 lifecycle rule as the
+  backstop: DynamoDB reaping an expired pointer item does not delete its S3
+  object.
+
+## Clean up
+
+```bash
+aws dynamodb delete-table --table-name agent-storage
+```

--- a/examples/ttl-sessions/ttl_sessions.py
+++ b/examples/ttl-sessions/ttl_sessions.py
@@ -1,0 +1,74 @@
+"""Self-expiring agent state with DynamoDB-native TTL.
+
+Ephemeral state accumulates fast in agent systems: anonymous visitor
+sessions, one-off tool scratch space, verification codes. Without a retention
+mechanism, someone ends up writing a cleanup job. With this package,
+retention is a constructor argument: every write stamps an epoch-seconds
+``expireAt`` attribute, reads and listings filter items whose expiry has
+passed, and DynamoDB physically reaps them in the background at no request
+cost.
+
+The script writes one item with a short TTL and one without, waits out the
+expiry, and shows all three views of the aftermath: the expired item is gone
+from ``read`` and ``list``, the persistent item is untouched, and the raw
+DynamoDB item may still be physically present for a while, which is why the
+package filters on read rather than trusting the reaper's timing.
+
+Prerequisites:
+  - A pk/sk table with TTL enabled on ``expireAt`` (see README.md).
+  - Credentials with PutItem/GetItem/DeleteItem/Query on the table.
+
+Usage:
+  python ttl_sessions.py --table agent-storage
+"""
+
+import argparse
+import asyncio
+
+import boto3
+from strands_dynamodb_storage import DynamoDBStorage
+
+TTL_SECONDS = 8
+
+
+async def main_async(table: str, region: str) -> None:
+    # ttl_seconds opts the store in to TTL: stamp on write, filter on read/list.
+    ephemeral = DynamoDBStorage(table, region_name=region, prefix="guest/g1", ttl_seconds=TTL_SECONDS)
+    durable = DynamoDBStorage(table, region_name=region, prefix="guest/g1")
+
+    await ephemeral.write("session/cart", b"3 items, checkout not started")
+    await durable.write("profile/consent", b"cookie banner accepted v3")
+    print(f"wrote session/cart with ttl_seconds={TTL_SECONDS}, profile/consent with no TTL")
+
+    data = await ephemeral.read("session/cart")
+    print(f"before expiry: read session/cart -> {data!r}")
+    print(f"before expiry: list ->  {sorted(await ephemeral.list('session/') + await durable.list('profile/'))}")
+
+    print(f"\nwaiting {TTL_SECONDS + 2}s for expiry...")
+    await asyncio.sleep(TTL_SECONDS + 2)
+
+    # The store filters the expired item immediately; DynamoDB reaps it later.
+    print(f"after expiry: read session/cart -> {await ephemeral.read('session/cart')}")
+    print(f"after expiry: list session/ -> {await ephemeral.list('session/')}")
+    print(f"after expiry: read profile/consent -> {await durable.read('profile/consent')}")
+
+    # Peek underneath: the raw item can still be physically present until the
+    # background reaper removes it. This is why the package filters on read.
+    ddb = boto3.client("dynamodb", region_name=region)
+    raw = ddb.get_item(TableName=table, Key={"pk": {"S": "guest/g1"}, "sk": {"S": "session/cart"}})
+    print(f"raw GetItem still returns an item: {'Item' in raw} (reaper removes it in the background)")
+
+    await durable.delete("profile/consent")
+    print("\ndemo items cleaned up (expired item left for the reaper)")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--table", default="agent-storage")
+    parser.add_argument("--region", default="us-east-1")
+    args = parser.parse_args()
+    asyncio.run(main_async(args.table, args.region))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Fourth entry in the examples library (follows #32, #33, #34). Self-contained: walkthrough README + runnable script, verified against real DynamoDB before submission.

## What it shows

Retention as a constructor argument via DynamoDB-native TTL: `ttl_seconds` stamps `expireAt` on every write, read/list filter already-expired items, and DynamoDB reaps them in the background at no request cost.

The script writes an ephemeral cart session and a durable consent record under one tenant prefix, waits out the expiry, and shows three views of the aftermath: the expired item gone from `read`/`list`, the durable item untouched, and (the teaching moment) a raw `GetItem` proving the expired item is still physically present until the reaper runs — which is exactly why the package filters on read instead of trusting reaper timing.

README carries the two considerations: `search()` can briefly return a logically expired item, and TTL + S3 offload needs a lifecycle rule as backstop.

## Verification

- Live us-east-1 table with TTL enabled on `expireAt`: all claims in the sample output are the actual live run (filtered read/list after expiry, durable item intact, raw item still present).
- Ruff (E,F,I,B, 120) and mypy 3.10 clean.

Independent of the other example PRs; no shared files.