### PR TITLE
docs: add examples/context-offload

### DIFF
--- a/examples/context-offload/README.md
+++ b/examples/context-offload/README.md
@@ -1,0 +1,82 @@
+# Transparent S3 offload for oversized values
+
+Agent workloads produce oversized values routinely: a tool returns a whole
+web page, a session accumulates a long transcript, a context offloader parks
+a large intermediate result. DynamoDB items cap at 400 KB. This example makes
+that cap invisible to the application.
+
+## How it works
+
+Configure the store with a bucket you own:
+
+```python
+storage = DynamoDBStorage(table, prefix="session/s1", s3_bucket="my-offload-bucket")
+```
+
+Values above the item-size limit are offloaded to Amazon S3, keyed by the
+item's full storage key, with a small pointer item remaining in the table.
+Values under the limit stay inline. `read` returns the full bytes either
+way, `list` sees every key regardless of where its value lives, and deleting
+a key reclaims the S3 object along with the item. Callers see one contract
+regardless of payload size.
+
+The script proves each of those statements: it writes 26 bytes and 1 MB
+through the same store, reads both back intact, then peeks underneath with
+raw DynamoDB and S3 calls to show the small value inline in its item, the
+large one as an S3 object behind a pointer item, and the object gone after
+delete.
+
+Optional gzip compression (`compression="gzip"`) is applied before the
+offload size check, so compressible values stay inline at lower cost.
+
+## Run it
+
+```bash
+aws dynamodb create-table \
+  --table-name agent-storage \
+  --attribute-definitions AttributeName=pk,AttributeType=S AttributeName=sk,AttributeType=S \
+  --key-schema AttributeName=pk,KeyType=HASH AttributeName=sk,KeyType=RANGE \
+  --billing-mode PAY_PER_REQUEST
+
+aws s3 mb s3://my-offload-bucket
+
+pip install strands-dynamodb-storage boto3
+python context_offload.py --table agent-storage --bucket my-offload-bucket
+```
+
+```text
+wrote 26 B and 1,036,013 B through the same contract
+read back 26 B and 1,036,013 B, both intact
+list sees both: ['turns/t1', 'turns/t2-page']
+
+turns/t1: DynamoDB item carries 26 B of data
+turns/t2-page: DynamoDB item carries 0 B of data (pointer item)
+S3 objects in bucket: [('session/s1/turns/t2-page', 1036013)]
+
+after delete: S3 objects remaining: 0
+```
+
+## Where this matters in an agent
+
+The Strands SDK's context offloader plugin parks oversized tool results
+through the same `Storage` contract, so an agent constructed with this store
+(`Agent(storage=storage, plugins=[ContextOffloader()])`) gets the S3
+spillover for free: big tool outputs leave the model context and land wherever
+the payload size says they should, with nothing in the agent code aware of
+the split.
+
+## Considerations
+
+- If you enable TTL on offloaded values, add an S3 lifecycle rule as the
+  backstop: DynamoDB reaping an expired pointer item does not delete its S3
+  object.
+- Runtime permissions extend to `s3:PutObject`, `s3:GetObject`, and
+  `s3:DeleteObject` on the bucket prefix; the README in the repository root
+  carries the full least-privilege policy.
+
+## Clean up
+
+```bash
+aws dynamodb delete-table --table-name agent-storage
+aws s3 rb s3://my-offload-bucket --force
+```

--- a/examples/context-offload/context_offload.py
+++ b/examples/context-offload/context_offload.py
@@ -1,0 +1,79 @@
+"""Store values beyond the DynamoDB item limit with transparent S3 offload.
+
+Agent workloads produce oversized values routinely: a tool returns a whole
+web page, a session accumulates a long transcript, a context offloader parks
+a large intermediate result. DynamoDB items cap at 400 KB. Configuring the
+store with an S3 bucket makes that cap invisible: values above the limit are
+offloaded to S3 with a small pointer item remaining in the table, and
+``read`` returns the full bytes either way. Callers see one contract
+regardless of payload size.
+
+The script writes a small value and a 1 MB value through the same store,
+reads both back, then peeks underneath to show where each physically lives:
+the small value inline in its DynamoDB item, the large one as an S3 object
+behind a pointer item. Deleting the key reclaims the S3 object too.
+
+Prerequisites:
+  - A pk/sk table (see README.md) and an S3 bucket you own.
+  - Credentials for the table plus s3:PutObject/GetObject/DeleteObject on
+    the bucket.
+
+Usage:
+  python context_offload.py --table agent-storage --bucket my-offload-bucket
+"""
+
+import argparse
+import asyncio
+
+import boto3
+from strands_dynamodb_storage import DynamoDBStorage
+
+LARGE_SIZE = 1_000_000  # 1 MB, over the 400 KB item limit
+
+
+async def main_async(table: str, bucket: str, region: str) -> None:
+    storage = DynamoDBStorage(table, region_name=region, prefix="session/s1", s3_bucket=bucket)
+
+    small = b"user asked about seat maps"
+    large = b"<html>" + b"tool result far too big for one item " * 28000 + b"</html>"
+    assert len(large) > LARGE_SIZE
+
+    await storage.write("turns/t1", small)
+    await storage.write("turns/t2-page", large)
+    print(f"wrote {len(small)} B and {len(large):,} B through the same contract")
+
+    # Reads are symmetric: full bytes come back either way.
+    r1 = await storage.read("turns/t1")
+    r2 = await storage.read("turns/t2-page")
+    assert r1 == small and r2 == large
+    print(f"read back {len(r1 or b'')} B and {len(r2 or b''):,} B, both intact")
+    print(f"list sees both: {sorted(await storage.list('turns/'))}\n")
+
+    # Peek underneath at where each value physically lives.
+    ddb = boto3.client("dynamodb", region_name=region)
+    s3 = boto3.client("s3", region_name=region)
+    for sk in ("turns/t1", "turns/t2-page"):
+        item = ddb.get_item(TableName=table, Key={"pk": {"S": "session/s1"}, "sk": {"S": sk}})["Item"]
+        size = len(item.get("data", {}).get("B", b""))
+        print(f"{sk}: DynamoDB item carries {size} B of data" + ("" if size else " (pointer item)"))
+    objects = s3.list_objects_v2(Bucket=bucket).get("Contents", [])
+    print(f"S3 objects in bucket: {[(o['Key'], o['Size']) for o in objects]}\n")
+
+    # Delete reclaims the S3 object along with the item.
+    await storage.delete("turns/t2-page")
+    await storage.delete("turns/t1")
+    remaining = s3.list_objects_v2(Bucket=bucket).get("KeyCount", 0)
+    print(f"after delete: S3 objects remaining: {remaining}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--table", default="agent-storage")
+    parser.add_argument("--bucket", required=True)
+    parser.add_argument("--region", default="us-east-1")
+    args = parser.parse_args()
+    asyncio.run(main_async(args.table, args.bucket, args.region))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Fifth entry in the examples library (follows #32–#35). Self-contained: walkthrough README + runnable script, verified against real DynamoDB and S3 before submission.

## What it shows

Transparent S3 spillover for values above the 400 KB item limit. The script writes 26 B and 1 MB through the same contract, reads both back intact, lists both keys, then peeks underneath with raw DynamoDB and S3 calls: the small value inline in its item, the large one as a zero-data pointer item plus an S3 object keyed by the full storage key, and the object reclaimed on delete.

README connects it to the SDK context offloader plugin (`Agent(storage=..., plugins=[ContextOffloader()])` gets the spillover for free), mentions gzip-before-size-check, and carries the TTL + lifecycle-rule caveat.

## Verification

- Live us-east-1 table + bucket: every line of the sample output in the README is the actual run (1,036,013 B round-trip intact, pointer item carries 0 B, S3 object reclaimed on delete, KeyCount 0 after).
- Ruff (E,F,I,B, 120) and mypy 3.10 clean.

Independent of the other example PRs; no shared files.