### PR TITLE
docs: add examples/customer-support

### DIFF
--- a/examples/customer-support/README.md
+++ b/examples/customer-support/README.md
@@ -1,0 +1,92 @@
+# Customer support assistant
+
+The capstone for this examples library: session persistence, long-term
+memory, and tenant isolation combined the way a real assistant uses them,
+with one DynamoDB table carrying all of it.
+
+## How it works
+
+One `DynamoDBStorage` instance, constructed with the customer's prefix,
+feeds both SDK managers:
+
+```python
+storage = DynamoDBStorage(table, prefix="customer/acme")
+session = SnapshotSessionManager("ticket-7341", storage=storage)
+memory = MemoryManager(stores=[DynamoDBMemoryStore(storage, ...)], add_tool_config=True)
+agent = Agent(system_prompt=..., session_manager=session, memory_manager=memory)
+```
+
+- The session manager snapshots the ticket conversation, so any process can
+  resume it: a redeploy, a handoff, tomorrow's follow-up.
+- The memory manager recalls the customer's account facts by meaning before
+  each model call, and `add_memory` lets the agent store new conclusions.
+- The constructor prefix and partition-scoped search keep every read, write,
+  and recall inside this customer's key space. Another customer's assistant
+  built the same way cannot reach any of it.
+
+## Run it
+
+Provision the vector-indexed table from the
+[semantic-memory example](../semantic-memory/README.md#run-it), then seed the
+customer's account facts:
+
+```bash
+pip install strands-agents strands-dynamodb-storage
+python support_assistant.py --table agent-storage seed
+```
+
+Open a ticket. The symptom shares no words with any stored fact:
+
+```bash
+python support_assistant.py --table agent-storage ticket \
+  "Our uploads keep failing after about a minute. Nothing changed on our side."
+```
+
+```text
+Tool #1: search_memory
+I found a likely culprit right away. Based on your account history, Acme's
+network runs an outbound proxy that closes idle connections after 60
+seconds. That aligns perfectly with uploads failing "after about a minute."
+...
+And since you prefer email communication, I can send a detailed write-up...
+```
+
+The agent connected "failing after about a minute" to a proxy memory it
+retrieved by meaning, folded in the pinned SDK version, and honored the
+contact preference, all from DynamoDB, none of it in the prompt.
+
+Come back to the ticket from a completely new process:
+
+```bash
+python support_assistant.py --table agent-storage ticket \
+  "Thanks. Summarize in one sentence what we concluded the cause was on this ticket."
+```
+
+```text
+The likely cause of your upload failures is Acme's outbound proxy closing
+idle connections after 60 seconds, which interrupts uploads that have brief
+idle gaps during data transfer.
+```
+
+The conclusion came from the resumed session snapshot; the new process
+started with nothing in memory.
+
+## What each example contributed
+
+| Capability | Shown alone in |
+|---|---|
+| Session resume across processes | [session-resume](../session-resume/) |
+| Recall by meaning on a vector index | [semantic-memory](../semantic-memory/) |
+| Per-customer isolation | [multi-tenant](../multi-tenant/) |
+| Self-expiring state | [ttl-sessions](../ttl-sessions/) |
+| Oversized values to S3 | [context-offload](../context-offload/) |
+
+Add `ttl_seconds` to the constructor to expire closed tickets, and
+`s3_bucket` to absorb oversized tool results; both compose with everything
+above without touching the agent code.
+
+## Clean up
+
+```bash
+aws dynamodb delete-table --table-name agent-storage
+```

--- a/examples/customer-support/support_assistant.py
+++ b/examples/customer-support/support_assistant.py
@@ -1,0 +1,143 @@
+"""A support assistant with per-customer memory, on one DynamoDB table.
+
+The capstone for this examples library: everything the other examples show,
+combined the way a real assistant uses it. One table carries, per customer:
+
+- **Session state**, so a ticket conversation survives restarts and handoffs
+  (``SnapshotSessionManager``).
+- **Long-term memories**, recalled by meaning across tickets
+  (``MemoryManager`` over a DynamoDB vector index).
+- **Tenant isolation**, so one customer's history never reaches another's
+  conversation (constructor prefix + partition-scoped search).
+
+The demo seeds account facts for one customer, then opens a support ticket
+in a fresh process: the customer reports dropped connections, and the agent
+connects that to a months-old memory about their proxy closing idle sockets,
+which shares no words with the complaint. A follow-up run resumes the same
+ticket from the persisted session.
+
+Prerequisites: vector-indexed table (see README.md), Bedrock access for the
+agent model and Titan embeddings.
+
+Usage:
+  python support_assistant.py --table agent-storage seed
+  python support_assistant.py --table agent-storage ticket \
+      "Our uploads keep failing after about a minute. Nothing changed on our side."
+  python support_assistant.py --table agent-storage ticket "Thanks. What did we conclude?"
+"""
+
+import argparse
+import asyncio
+import json
+import uuid
+from typing import Any, Optional
+
+import boto3
+from strands import Agent
+from strands.memory import MemoryEntry, MemoryManager
+from strands.memory.types import Metadata, SearchOptions
+from strands.session import SnapshotSessionManager
+from strands_dynamodb_storage import DynamoDBStorage, SearchQuery
+
+CUSTOMER = "customer/acme"
+TICKET_SESSION = "ticket-7341"
+
+ACCOUNT_FACTS = [
+    "Acme's network runs an outbound proxy that closes idle connections after 60 seconds",
+    "Acme pinned their integration to a custom build of the SDK, version 2.14",
+    "Acme's technical contact prefers email and asked not to be called by phone",
+]
+
+SYSTEM_PROMPT = (
+    "You are a support engineer for a data-transfer service. Use the customer's "
+    "account memories when they are relevant to the reported symptom, and say "
+    "which remembered fact you are basing your answer on."
+)
+
+
+def make_embedder(region: str) -> Any:
+    bedrock = boto3.client("bedrock-runtime", region_name=region)
+
+    def embed(text: str) -> list[float]:
+        response = bedrock.invoke_model(
+            modelId="amazon.titan-embed-text-v2:0",
+            body=json.dumps({"inputText": text, "dimensions": 1024}),
+        )
+        return json.loads(response["body"].read())["embedding"]  # type: ignore[no-any-return]
+
+    return embed
+
+
+class DynamoDBMemoryStore:
+    """Adapts DynamoDBStorage vector search to the Strands MemoryStore protocol."""
+
+    def __init__(self, storage: DynamoDBStorage, partition: str, embed: Any) -> None:
+        self.storage = storage
+        self.partition = partition
+        self.embed = embed
+        self.name = "account-memory"
+        self.description = "This customer's account facts and history, searched by meaning"
+        self.max_search_results = 3
+        self.writable = True
+        self.extraction = None
+
+    async def add(self, content: str, metadata: Optional[Metadata] = None) -> None:
+        await self.storage.write(
+            f"memories/{uuid.uuid4().hex[:8]}",
+            content.encode(),
+            vector=self.embed(content),
+            metadata=metadata,
+        )
+
+    async def search(self, query: str, options: Optional[SearchOptions] = None) -> list[MemoryEntry]:
+        results = await self.storage.search(
+            SearchQuery(
+                vector=self.embed(query),
+                top_k=self.max_search_results,
+                pk=self.partition,
+                include_values=True,
+            )
+        )
+        return [
+            MemoryEntry(content=r.data.decode(), metadata=r.metadata)
+            for r in results
+            if r.data is not None
+        ]
+
+
+def build_agent(table: str, region: str) -> Agent:
+    """One storage instance carries the whole assistant for this customer."""
+    storage = DynamoDBStorage(table, region_name=region, prefix=CUSTOMER)
+    store = DynamoDBMemoryStore(storage, partition=CUSTOMER, embed=make_embedder(region))
+    # MemoryStore's optional methods are detected at runtime by the manager,
+    # but mypy requires them structurally.
+    memory = MemoryManager(stores=[store], add_tool_config=True)  # type: ignore[list-item]
+    session = SnapshotSessionManager(TICKET_SESSION, storage=storage)
+    return Agent(system_prompt=SYSTEM_PROMPT, session_manager=session, memory_manager=memory)
+
+
+async def seed(table: str, region: str) -> None:
+    storage = DynamoDBStorage(table, region_name=region, prefix=CUSTOMER)
+    store = DynamoDBMemoryStore(storage, partition=CUSTOMER, embed=make_embedder(region))
+    for fact in ACCOUNT_FACTS:
+        await store.add(fact, metadata={"kind": "account-fact"})
+        print(f"stored: {fact}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--table", default="agent-storage")
+    parser.add_argument("--region", default="us-east-1")
+    parser.add_argument("verb", choices=["seed", "ticket"])
+    parser.add_argument("message", nargs="?", default="Our uploads keep failing after about a minute.")
+    args = parser.parse_args()
+
+    if args.verb == "seed":
+        asyncio.run(seed(args.table, args.region))
+    else:
+        agent = build_agent(args.table, args.region)
+        agent(args.message)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Final entry in the examples library (follows #32–#36): the capstone that combines the single-capability examples the way a real assistant uses them.

## What it shows

One `DynamoDBStorage` instance per customer feeding both SDK managers: `SnapshotSessionManager` resuming a support ticket across processes, `MemoryManager` recalling account facts by meaning via the vector index (with `add_memory` enabled), and the constructor prefix + partition-scoped search keeping every read, write, and recall inside the customer key space. One table carries all of it.

The README cross-links each single-capability example in a table and notes that `ttl_seconds` and `s3_bucket` compose in without touching agent code.

## Verification (live us-east-1 vector-indexed table)

- Seeded 3 account facts; a fresh process connected "uploads keep failing after about a minute" to the stored proxy-closes-idle-connections-after-60s memory (no shared words), folded in the pinned SDK version, and honored the email contact preference — all via the `search_memory` tool path.
- A third process resumed the same ticket and restated the conclusion from the persisted session snapshot.
- Ruff (E,F,I,B, 120) and mypy 3.10 clean.

Self-contained (the MemoryStore bridge is duplicated rather than imported across examples, so each example remains copy-paste-able). Independent of the other example PRs; no shared files.