### PR TITLE
docs: add examples index and link it from the package READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,10 @@ await storage.list('sessions/s1/')
 
 More in the [TypeScript README](typescript/), including the structured `DynamoDBListQuery` extension and typed search results.
 
+## Examples
+
+The [examples library](examples/) carries a runnable, live-verified example for each capability: session resume across restarts, semantic long-term memory with the Memory Manager, multi-tenant isolation, self-expiring TTL state, S3 offload for oversized values, and a customer-support capstone that combines them on one table. Each is a self-contained directory you can copy into your own project.
+
 ## Provisioning and permissions
 
 **You own the table.** The package never creates infrastructure: it holds no `CreateTable` or `UpdateTable` permission at runtime, so the table lives in your infrastructure as code next to your other resources, with your tagging, backup, and encryption posture applied. Everything it needs is a table with a string partition key `pk` and a string sort key `sk`:

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,57 @@
+# Examples
+
+Runnable, self-contained examples for strands-dynamodb-storage. Every example
+was executed against real Amazon DynamoDB before it landed here, and the
+sample output in each README is the actual run. Each directory stands alone:
+a walkthrough README, one script, and nothing shared, so you can copy a
+directory into your own project and start from there.
+
+## Start here
+
+| | Example | What it shows | The DynamoDB angle |
+|---|---|---|---|
+| 🔄 | [session-resume](./session-resume/) | A conversation survives a restart: a brand-new process picks up the thread from a persisted snapshot | Point reads on the hot path of every agent turn |
+| 🧠 | [semantic-memory](./semantic-memory/) | Long-term memory recalled by meaning, with the `MemoryStore` bridge class and Memory Manager wiring | A vector index on the same table as the agent's state |
+| 🏢 | [multi-tenant](./multi-tenant/) | Two users share a table; listings and searches provably never cross the boundary | Prefix-scoped keys and partition-scoped vector search |
+| ⏳ | [ttl-sessions](./ttl-sessions/) | Ephemeral state that expires itself, with no cleanup job to write | Native TTL: stamp on write, filter on read, reap in the background |
+| 📦 | [context-offload](./context-offload/) | A 1 MB value round-trips through the same four-method contract as a 26-byte one | Transparent S3 spillover behind a pointer item |
+| 🎧 | [customer-support](./customer-support/) | The capstone: session resume, semantic recall, and tenant isolation combined in one assistant | One table carrying everything the agent remembers |
+
+If you are new to the package, run them in that order: each example
+introduces one capability, and the capstone assembles them the way a real
+assistant uses them.
+
+## Picking by problem
+
+- "My agent forgets everything on redeploy" → [session-resume](./session-resume/)
+- "My agent can't recall what the user said last month" → [semantic-memory](./semantic-memory/)
+- "One table, many customers, zero crossover" → [multi-tenant](./multi-tenant/)
+- "Anonymous sessions are piling up in my table" → [ttl-sessions](./ttl-sessions/)
+- "A tool result blew the 400 KB item limit" → [context-offload](./context-offload/)
+- "Show me all of it working together" → [customer-support](./customer-support/)
+
+## Running the examples
+
+Every example needs a DynamoDB table with string keys `pk` and `sk`; the ones
+that search memories also need a vector index, and each README opens with the
+exact `create-table` call it expects. Credentials follow the least-privilege
+policy in the [repository README](../README.md#provisioning-and-permissions).
+The scripts are Python; the TypeScript package is a feature-parity mirror, so
+every pattern translates directly.
+
+```bash
+pip install strands-agents strands-dynamodb-storage
+cd session-resume
+python session_resume.py --table agent-storage tell "My rental car is a blue Nissan Micra"
+```
+
+Examples that invoke a model use Amazon Bedrock: the agent examples run on
+your configured default model, and embeddings use Amazon Titan Text
+Embeddings V2 (1024 dimensions, matching the vector index in each README).
+
+## Contributing an example
+
+Keep the shape: one directory, one README that a reader can follow without
+running anything, one script that runs end to end against real DynamoDB, and
+no imports from sibling examples. If it shows something the table above
+doesn't already cover, we'd love to see it.

--- a/python/README.md
+++ b/python/README.md
@@ -102,6 +102,12 @@ Like a global secondary index, the vector index is eventually consistent, and a 
 created index backfills before it is searchable. Requires `boto3 >= 1.43.64`; a
 `vector_search` adapter, when configured, overrides the native call (testing, custom routing).
 
+## Examples
+
+Runnable, live-verified examples for every capability, from session resume to a
+customer-support capstone, live in the
+[examples library](https://github.com/aws/strands-dynamodb-storage/tree/main/examples).
+
 ## Development
 
 ```bash

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -221,6 +221,14 @@ The adapter is purely an override: with none configured, `search()` issues the n
 The full provisioning story (TTL enablement, vector index creation, and the complete least-privilege policy) is in the
 repository README's [Provisioning and permissions](../#provisioning-and-permissions).
 
+## Examples
+
+Runnable, live-verified examples for every capability, from session resume to a
+customer-support capstone, live in the
+[examples library](https://github.com/aws/strands-dynamodb-storage/tree/main/examples).
+The scripts are Python; this package is a feature-parity mirror, so every pattern
+translates directly.
+
 ## License
 
 Apache-2.0


### PR DESCRIPTION
Caps the examples library (#32–#37).

## What it adds

- **`examples/README.md`**: capability table (what each example shows + the DynamoDB angle for each), a problem-based quick-pick ("my agent forgets everything on redeploy" → session-resume), shared run instructions, and the contribution shape for future examples (one self-contained directory, live-verified, no sibling imports).
- **Root README**: an Examples section between the quick starts and Provisioning.
- **`python/README.md` + `typescript/README.md`**: Examples sections with absolute GitHub URLs, since relative links do not resolve on PyPI/npm.

## Merge order

The index links all six examples including `customer-support`, so merge #37 first (or together — the link is the only coupling).

Docs-only; no code changes.