### PR TITLE
feat(examples): add TypeScript mirrors for all six examples

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -36,13 +36,20 @@ Every example needs a DynamoDB table with string keys `pk` and `sk`; the ones
 that search memories also need a vector index, and each README opens with the
 exact `create-table` call it expects. Credentials follow the least-privilege
 policy in the [repository README](../README.md#provisioning-and-permissions).
-The scripts are Python; the TypeScript package is a feature-parity mirror, so
-every pattern translates directly.
+The scripts come in both languages: each directory carries a Python script
+and a TypeScript mirror side by side, running the same pattern against the
+same table.
 
 ```bash
 pip install strands-agents strands-dynamodb-storage
 cd session-resume
 python session_resume.py --table agent-storage tell "My rental car is a blue Nissan Micra"
+```
+
+```bash
+npm install @strands-agents/sdk strands-dynamodb-storage tsx
+cd session-resume
+npx tsx session-resume.ts --table agent-storage tell "My rental car is a blue Nissan Micra"
 ```
 
 Examples that invoke a model use Amazon Bedrock: the agent examples run on

--- a/examples/context-offload/README.md
+++ b/examples/context-offload/README.md
@@ -44,6 +44,13 @@ pip install strands-dynamodb-storage boto3
 python context_offload.py --table agent-storage --bucket my-offload-bucket
 ```
 
+Or the TypeScript equivalent:
+
+```bash
+npm install strands-dynamodb-storage @strands-agents/sdk @aws-sdk/client-dynamodb @aws-sdk/lib-dynamodb @aws-sdk/client-s3 tsx
+npx tsx context-offload.ts --table agent-storage --bucket my-offload-bucket
+```
+
 ```text
 wrote 26 B and 1,036,013 B through the same contract
 read back 26 B and 1,036,013 B, both intact

--- a/examples/context-offload/context-offload.ts
+++ b/examples/context-offload/context-offload.ts
@@ -1,0 +1,90 @@
+/**
+ * Store values beyond the DynamoDB item limit with transparent S3 offload.
+ *
+ * Agent workloads produce oversized values routinely: a tool returns a whole
+ * web page, a session accumulates a long transcript, a context offloader parks
+ * a large intermediate result. DynamoDB items cap at 400 KB. Configuring the
+ * store with an S3 bucket makes that cap invisible: values above the limit are
+ * offloaded to S3 with a small pointer item remaining in the table, and
+ * `read` returns the full bytes either way. Callers see one contract
+ * regardless of payload size.
+ *
+ * The script writes a small value and a 1 MB value through the same store,
+ * reads both back, then peeks underneath to show where each physically lives:
+ * the small value inline in its DynamoDB item, the large one as an S3 object
+ * behind a pointer item. Deleting the key reclaims the S3 object too.
+ *
+ * Prerequisites:
+ *   - A pk/sk table (see README.md) and an S3 bucket you own.
+ *   - Credentials for the table plus s3:PutObject/GetObject/DeleteObject on
+ *     the bucket.
+ *
+ * Usage:
+ *   npx tsx context-offload.ts --table agent-storage --bucket my-offload-bucket
+ */
+
+import { parseArgs } from 'node:util';
+import assert from 'node:assert/strict';
+
+import { DynamoDBClient, GetItemCommand } from '@aws-sdk/client-dynamodb';
+import { ListObjectsV2Command, S3Client } from '@aws-sdk/client-s3';
+import { DynamoDBStorage } from 'strands-dynamodb-storage';
+
+const LARGE_SIZE = 1_000_000; // 1 MB, over the 400 KB item limit
+
+async function main(table: string, bucket: string, region: string): Promise<void> {
+  const storage = new DynamoDBStorage(table, { region, prefix: 'session/s1', s3Bucket: bucket });
+
+  const small = Buffer.from('user asked about seat maps');
+  const large = Buffer.concat([
+    Buffer.from('<html>'),
+    Buffer.from('tool result far too big for one item '.repeat(28_000)),
+    Buffer.from('</html>'),
+  ]);
+  assert.ok(large.length > LARGE_SIZE);
+
+  await storage.write('turns/t1', small);
+  await storage.write('turns/t2-page', large);
+  console.log(`wrote ${small.length} B and ${large.length.toLocaleString('en-US')} B through the same contract`);
+
+  // Reads are symmetric: full bytes come back either way.
+  const r1 = await storage.read('turns/t1');
+  const r2 = await storage.read('turns/t2-page');
+  assert.ok(r1 !== null && Buffer.from(r1).equals(small));
+  assert.ok(r2 !== null && Buffer.from(r2).equals(large));
+  console.log(`read back ${r1.length} B and ${r2.length.toLocaleString('en-US')} B, both intact`);
+  console.log(`list sees both: ${JSON.stringify([...(await storage.list('turns/'))].sort())}\n`);
+
+  // Peek underneath at where each value physically lives.
+  const ddb = new DynamoDBClient({ region });
+  const s3 = new S3Client({ region });
+  for (const sk of ['turns/t1', 'turns/t2-page']) {
+    const { Item } = await ddb.send(
+      new GetItemCommand({ TableName: table, Key: { pk: { S: 'session/s1' }, sk: { S: sk } } }),
+    );
+    const size = Item?.data?.B?.length ?? 0;
+    console.log(`${sk}: DynamoDB item carries ${size} B of data${size ? '' : ' (pointer item)'}`);
+  }
+  const objects = (await s3.send(new ListObjectsV2Command({ Bucket: bucket }))).Contents ?? [];
+  console.log(`S3 objects in bucket: ${JSON.stringify(objects.map((o) => [o.Key, o.Size]))}\n`);
+
+  // Delete reclaims the S3 object along with the item.
+  await storage.delete('turns/t2-page');
+  await storage.delete('turns/t1');
+  const remaining = (await s3.send(new ListObjectsV2Command({ Bucket: bucket }))).KeyCount ?? 0;
+  console.log(`after delete: S3 objects remaining: ${remaining}`);
+}
+
+const { values } = parseArgs({
+  options: {
+    table: { type: 'string', default: 'agent-storage' },
+    bucket: { type: 'string' },
+    region: { type: 'string', default: 'us-east-1' },
+  },
+});
+if (values.bucket === undefined) {
+  console.error('error: the following argument is required: --bucket');
+  process.exit(2);
+}
+
+await main(values.table, values.bucket, values.region);

--- a/examples/customer-support/README.md
+++ b/examples/customer-support/README.md
@@ -35,6 +35,16 @@ pip install strands-agents strands-dynamodb-storage
 python support_assistant.py --table agent-storage seed
 ```
 
+Or the TypeScript equivalent:
+
+```bash
+npm install @strands-agents/sdk strands-dynamodb-storage tsx @aws-sdk/client-bedrock-runtime
+npx tsx support-assistant.ts --table agent-storage seed
+```
+
+Every `python support_assistant.py` command below runs the same with
+`npx tsx support-assistant.ts`.
+
 Open a ticket. The symptom shares no words with any stored fact:
 
 ```bash

--- a/examples/customer-support/support-assistant.ts
+++ b/examples/customer-support/support-assistant.ts
@@ -1,0 +1,161 @@
+/**
+ * A support assistant with per-customer memory, on one DynamoDB table.
+ *
+ * The capstone for this examples library: everything the other examples show,
+ * combined the way a real assistant uses it. One table carries, per customer:
+ *
+ * - **Session state**, so a ticket conversation survives restarts and handoffs
+ *   (`SessionManager`).
+ * - **Long-term memories**, recalled by meaning across tickets
+ *   (`MemoryManager` over a DynamoDB vector index).
+ * - **Tenant isolation**, so one customer's history never reaches another's
+ *   conversation (constructor prefix + partition-scoped search).
+ *
+ * The demo seeds account facts for one customer, then opens a support ticket
+ * in a fresh process: the customer reports dropped connections, and the agent
+ * connects that to a months-old memory about their proxy closing idle sockets,
+ * which shares no words with the complaint. A follow-up run resumes the same
+ * ticket from the persisted session.
+ *
+ * Prerequisites: vector-indexed table (see README.md), Bedrock access for the
+ * agent model and Titan embeddings.
+ *
+ * Usage:
+ *   npx tsx support-assistant.ts --table agent-storage seed
+ *   npx tsx support-assistant.ts --table agent-storage ticket \
+ *       "Our uploads keep failing after about a minute. Nothing changed on our side."
+ *   npx tsx support-assistant.ts --table agent-storage ticket "Thanks. What did we conclude?"
+ */
+
+import { randomUUID } from 'node:crypto'
+import { parseArgs } from 'node:util'
+
+import { BedrockRuntimeClient, InvokeModelCommand } from '@aws-sdk/client-bedrock-runtime'
+import { Agent, MemoryManager, SessionManager } from '@strands-agents/sdk'
+import type { JSONValue, MemoryEntry, MemoryStore, SearchOptions } from '@strands-agents/sdk'
+import { DynamoDBStorage } from 'strands-dynamodb-storage'
+import type { SearchQuery } from 'strands-dynamodb-storage'
+
+const CUSTOMER = 'customer/acme'
+const TICKET_SESSION = 'ticket-7341'
+
+const ACCOUNT_FACTS = [
+  "Acme's network runs an outbound proxy that closes idle connections after 60 seconds",
+  "Acme pinned their integration to a custom build of the SDK, version 2.14",
+  "Acme's technical contact prefers email and asked not to be called by phone",
+]
+
+const SYSTEM_PROMPT =
+  "You are a support engineer for a data-transfer service. Use the customer's " +
+  'account memories when they are relevant to the reported symptom, and say ' +
+  'which remembered fact you are basing your answer on.'
+
+type Embedder = (text: string) => Promise<number[]>
+
+function makeEmbedder(region: string): Embedder {
+  const bedrock = new BedrockRuntimeClient({ region })
+
+  return async (text: string): Promise<number[]> => {
+    const response = await bedrock.send(
+      new InvokeModelCommand({
+        modelId: 'amazon.titan-embed-text-v2:0',
+        body: JSON.stringify({ inputText: text, dimensions: 1024 }),
+      }),
+    )
+    const parsed = JSON.parse(new TextDecoder().decode(response.body)) as { embedding: number[] }
+    return parsed.embedding
+  }
+}
+
+/** Adapts DynamoDBStorage vector search to the Strands MemoryStore interface. */
+class DynamoDBMemoryStore implements MemoryStore {
+  readonly name = 'account-memory'
+  readonly description = "This customer's account facts and history, searched by meaning"
+  readonly maxSearchResults = 3
+  readonly writable = true
+
+  constructor(
+    private readonly storage: DynamoDBStorage,
+    private readonly partition: string,
+    private readonly embed: Embedder,
+  ) {}
+
+  async add(content: string, metadata?: Record<string, JSONValue>): Promise<void> {
+    // The storage backend indexes flat primitive metadata; keep those entries.
+    const flat: Record<string, string | number | boolean> = {}
+    for (const [key, value] of Object.entries(metadata ?? {})) {
+      if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+        flat[key] = value
+      }
+    }
+    await this.storage.write(
+      `memories/${randomUUID().replaceAll('-', '').slice(0, 8)}`,
+      new TextEncoder().encode(content),
+      { vector: await this.embed(content), metadata: flat },
+    )
+  }
+
+  async search(query: string, _options?: SearchOptions): Promise<MemoryEntry[]> {
+    const searchQuery: SearchQuery = {
+      vector: await this.embed(query),
+      topK: this.maxSearchResults,
+      pk: this.partition,
+      includeValues: true,
+    }
+    const results = await this.storage.search(searchQuery)
+    return results.flatMap((r) =>
+      r.data === undefined
+        ? []
+        : [
+            {
+              content: new TextDecoder().decode(r.data),
+              metadata: r.metadata as Record<string, JSONValue> | undefined,
+            },
+          ],
+    )
+  }
+}
+
+/** One storage instance carries the whole assistant for this customer. */
+function buildAgent(table: string, region: string): Agent {
+  const storage = new DynamoDBStorage(table, { region, prefix: CUSTOMER })
+  const store = new DynamoDBMemoryStore(storage, CUSTOMER, makeEmbedder(region))
+  const memory = new MemoryManager({ stores: [store], addToolConfig: true })
+  const session = new SessionManager({ sessionId: TICKET_SESSION, storage })
+  return new Agent({ systemPrompt: SYSTEM_PROMPT, sessionManager: session, memoryManager: memory })
+}
+
+async function seed(table: string, region: string): Promise<void> {
+  const storage = new DynamoDBStorage(table, { region, prefix: CUSTOMER })
+  const store = new DynamoDBMemoryStore(storage, CUSTOMER, makeEmbedder(region))
+  for (const fact of ACCOUNT_FACTS) {
+    await store.add(fact, { kind: 'account-fact' })
+    console.log(`stored: ${fact}`)
+  }
+}
+
+async function main(): Promise<void> {
+  const { values, positionals } = parseArgs({
+    options: {
+      table: { type: 'string', default: 'agent-storage' },
+      region: { type: 'string', default: 'us-east-1' },
+    },
+    allowPositionals: true,
+  })
+  const [verb, message = 'Our uploads keep failing after about a minute.'] = positionals
+  if (verb !== 'seed' && verb !== 'ticket') {
+    console.error(
+      'usage: npx tsx support-assistant.ts [--table NAME] [--region REGION] {seed|ticket} [message]',
+    )
+    process.exit(2)
+  }
+
+  if (verb === 'seed') {
+    await seed(values.table, values.region)
+  } else {
+    const agent = buildAgent(values.table, values.region)
+    await agent.invoke(message)
+  }
+}
+
+await main()

--- a/examples/multi-tenant/README.md
+++ b/examples/multi-tenant/README.md
@@ -44,6 +44,13 @@ pip install strands-dynamodb-storage boto3
 python multi_tenant.py --table agent-storage
 ```
 
+Or the TypeScript equivalent:
+
+```bash
+npm install strands-dynamodb-storage @aws-sdk/client-bedrock-runtime tsx
+npx tsx multi-tenant.ts --table agent-storage
+```
+
 ```text
 seeded one coffee memory per user (same logical key memories/m1)
 

--- a/examples/multi-tenant/multi-tenant.ts
+++ b/examples/multi-tenant/multi-tenant.ts
@@ -1,0 +1,109 @@
+/**
+ * Serve many tenants from one DynamoDB table, with per-tenant isolation.
+ *
+ * A memory store serving many users has to keep one user's memories out of
+ * another user's results. With this package that is a schema decision made at
+ * construction time, not a filter appended to every query:
+ *
+ * - The constructor `prefix` pins every write, read, and listing inside the
+ *   tenant's own key space, so two tenants resolve the same logical key to
+ *   physically distinct partitions.
+ * - The vector index is partitioned by `pk` (its search schema HASH element),
+ *   so a search scoped to one tenant's partition never ranges over another
+ *   tenant's vectors, no matter how similar they are.
+ *
+ * This script seeds two users with near-identical memories, then shows that
+ * listings and semantic searches for one user never surface the other's data,
+ * even when the other user's memory is the closest match in the whole table.
+ *
+ * Prerequisites: vector-indexed table (see README.md), Bedrock access for
+ * Titan embeddings.
+ *
+ * Usage:
+ *   npx tsx multi-tenant.ts --table agent-storage
+ */
+
+import { parseArgs } from 'node:util'
+
+import { BedrockRuntimeClient, InvokeModelCommand } from '@aws-sdk/client-bedrock-runtime'
+import { DynamoDBStorage } from 'strands-dynamodb-storage'
+import type { SearchQuery } from 'strands-dynamodb-storage'
+
+const ALICE = 'user/alice'
+const BOB = 'user/bob'
+
+function makeEmbedder(region: string): (text: string) => Promise<number[]> {
+  const bedrock = new BedrockRuntimeClient({ region })
+
+  return async (text: string): Promise<number[]> => {
+    const response = await bedrock.send(
+      new InvokeModelCommand({
+        modelId: 'amazon.titan-embed-text-v2:0',
+        body: JSON.stringify({ inputText: text, dimensions: 1024 }),
+      }),
+    )
+    const { embedding } = JSON.parse(new TextDecoder().decode(response.body)) as {
+      embedding: number[]
+    }
+    return embedding
+  }
+}
+
+async function main(table: string, region: string): Promise<void> {
+  const embed = makeEmbedder(region)
+  const encoder = new TextEncoder()
+  const decoder = new TextDecoder()
+
+  // One store per tenant. Same table, same code path; only the prefix differs.
+  const alice = new DynamoDBStorage(table, { region, prefix: ALICE })
+  const bob = new DynamoDBStorage(table, { region, prefix: BOB })
+
+  // Near-identical content on both sides. If scoping leaked, Bob's espresso
+  // memory would be the nearest neighbor for Alice's coffee question.
+  await alice.write('memories/m1', encoder.encode('Alice drinks oat-milk lattes, decaf after noon'), {
+    vector: await embed('Alice drinks oat-milk lattes, decaf after noon'),
+  })
+  await bob.write('memories/m1', encoder.encode('Bob drinks double espressos, no milk ever'), {
+    vector: await embed('Bob drinks double espressos, no milk ever'),
+  })
+  console.log('seeded one coffee memory per user (same logical key memories/m1)\n')
+
+  // 1. The byte contract is scoped: each tenant lists only its own keys.
+  console.log(`alice.list('memories/') -> ${JSON.stringify(await alice.list('memories/'))}`)
+  console.log(`bob.list('memories/')   -> ${JSON.stringify(await bob.list('memories/'))}\n`)
+
+  // 2. Search is scoped by partition: each tenant's query is answered only
+  //    from that tenant's vectors.
+  const question = 'how does this user take their coffee?'
+  const tenants: Array<[string, DynamoDBStorage, string]> = [
+    ['alice', alice, ALICE],
+    ['bob', bob, BOB],
+  ]
+  for (const [name, store, pk] of tenants) {
+    const query: SearchQuery = { vector: await embed(question), topK: 5, pk, includeValues: true }
+    const results = await store.search(query)
+    const answers = results.filter((r) => r.data != null).map((r) => decoder.decode(r.data))
+    console.log(`search as ${name}: ${JSON.stringify(answers)}`)
+    const other = name === 'alice' ? 'Bob' : 'Alice'
+    const leaked = answers.some((a) => a.includes(other))
+    console.log(`  ${other}'s memory in ${name}'s results: ${leaked}`)
+    if (leaked) throw new Error('cross-tenant leak')
+  }
+
+  // Clean up the demo items.
+  await alice.delete('memories/m1')
+  await bob.delete('memories/m1')
+  console.log('\ndemo items deleted')
+}
+
+const { values } = parseArgs({
+  options: {
+    table: { type: 'string', default: 'agent-storage' },
+    region: { type: 'string', default: 'us-east-1' },
+  },
+})
+
+main(values.table, values.region).catch((err) => {
+  console.error(err)
+  process.exitCode = 1
+})

--- a/examples/semantic-memory/README.md
+++ b/examples/semantic-memory/README.md
@@ -70,6 +70,16 @@ python semantic_memory.py --table agent-storage ask \
   "Book me a flight seat for my December trip. Which seat should I pick?"
 ```
 
+Or the TypeScript equivalent:
+
+```bash
+npm install @strands-agents/sdk strands-dynamodb-storage @aws-sdk/client-bedrock-runtime tsx
+
+npx tsx semantic-memory.ts --table agent-storage seed
+npx tsx semantic-memory.ts --table agent-storage ask \
+  "Book me a flight seat for my December trip. Which seat should I pick?"
+```
+
 ```text
 Tool #1: search_memory
 Based on your saved preferences and trip details, here's what I found:

--- a/examples/semantic-memory/semantic-memory.ts
+++ b/examples/semantic-memory/semantic-memory.ts
@@ -1,0 +1,141 @@
+/**
+ * Give an agent long-term memory it can search by meaning, on one DynamoDB table.
+ *
+ * Session persistence gets a conversation through a restart. This example covers
+ * the other half: recalling something a user said weeks ago, in a new
+ * conversation that shares no keys or words with the old one. Memories are
+ * embedded on write, stored with a vector alongside the bytes, and recalled with
+ * a DynamoDB vector index search scoped to the user's partition.
+ *
+ * The `DynamoDBMemoryStore` class here is application code: the package ships
+ * the storage contract and vector search, and this bridge adapts them to the
+ * Strands SDK's `MemoryStore` interface so the Memory Manager can pull relevant
+ * memories into the model input before each call.
+ *
+ * Prerequisites:
+ *   - A DynamoDB table with a vector index (see README.md; 1024 dims, COSINE).
+ *   - Credentials for the table, dynamodb:SearchVectors, and Bedrock InvokeModel
+ *     (agent model + amazon.titan-embed-text-v2:0 for embeddings).
+ *
+ * Usage:
+ *   npx tsx semantic-memory.ts --table agent-storage seed
+ *   npx tsx semantic-memory.ts --table agent-storage ask \
+ *       "Book me a flight seat for my December trip. Which seat should I pick?"
+ */
+
+import { randomUUID } from 'node:crypto'
+import { parseArgs } from 'node:util'
+
+import { BedrockRuntimeClient, InvokeModelCommand } from '@aws-sdk/client-bedrock-runtime'
+import { Agent, MemoryManager } from '@strands-agents/sdk'
+import type { MemoryEntry, MemoryStore, SearchOptions } from '@strands-agents/sdk'
+import { DynamoDBStorage } from 'strands-dynamodb-storage'
+import type { SearchQuery, SearchResult } from 'strands-dynamodb-storage'
+
+const USER_PARTITION = 'user/u1'
+
+const SEED_MEMORIES = [
+  'Prefers window seats on long flights',
+  'Planning a trip to Tokyo in December',
+  'Has a peanut allergy, flag it when booking meals',
+]
+
+type Embedder = (text: string) => Promise<number[]>
+
+/** Return an embed(text) -> number[] callable backed by Titan V2 (1024 dims). */
+function makeEmbedder(region: string): Embedder {
+  const bedrock = new BedrockRuntimeClient({ region })
+
+  return async (text: string): Promise<number[]> => {
+    const response = await bedrock.send(
+      new InvokeModelCommand({
+        modelId: 'amazon.titan-embed-text-v2:0',
+        body: JSON.stringify({ inputText: text, dimensions: 1024 }),
+      }),
+    )
+    const parsed = JSON.parse(new TextDecoder().decode(response.body)) as { embedding: number[] }
+    return parsed.embedding
+  }
+}
+
+/** Adapts DynamoDBStorage vector search to the Strands MemoryStore interface. */
+class DynamoDBMemoryStore implements MemoryStore {
+  readonly name = 'dynamodb'
+  readonly description = 'Long-term memories in DynamoDB, searched by meaning'
+  readonly maxSearchResults = 3
+  readonly writable = true
+
+  constructor(
+    private readonly storage: DynamoDBStorage,
+    private readonly partition: string,
+    private readonly embed: Embedder,
+  ) {}
+
+  async add(content: string, metadata?: Record<string, string | number | boolean>): Promise<void> {
+    await this.storage.write(
+      `memories/${randomUUID().replace(/-/g, '').slice(0, 8)}`,
+      new TextEncoder().encode(content),
+      { vector: await this.embed(content), metadata },
+    )
+  }
+
+  async search(query: string, options?: SearchOptions): Promise<MemoryEntry[]> {
+    const request: SearchQuery = {
+      vector: await this.embed(query),
+      topK: this.maxSearchResults,
+      pk: this.partition,
+      includeValues: true,
+    }
+    const results = await this.storage.search(request)
+    const decoder = new TextDecoder()
+    return results
+      .filter((r): r is SearchResult & { data: Uint8Array } => r.data !== undefined)
+      .map((r) => ({
+        content: decoder.decode(r.data),
+        metadata: r.metadata as MemoryEntry['metadata'],
+      }))
+  }
+}
+
+function buildStore(table: string, region: string): DynamoDBMemoryStore {
+  const storage = new DynamoDBStorage(table, { region, prefix: USER_PARTITION })
+  return new DynamoDBMemoryStore(storage, USER_PARTITION, makeEmbedder(region))
+}
+
+async function seed(store: DynamoDBMemoryStore): Promise<void> {
+  for (const memory of SEED_MEMORIES) {
+    await store.add(memory, { kind: 'preference' })
+    console.log(`stored: ${memory}`)
+  }
+}
+
+async function ask(store: DynamoDBMemoryStore, question: string): Promise<void> {
+  const memory = new MemoryManager({ stores: [store], addToolConfig: true })
+  const agent = new Agent({ memoryManager: memory })
+  await agent.invoke(question)
+}
+
+async function main(): Promise<void> {
+  const { values, positionals } = parseArgs({
+    options: {
+      table: { type: 'string', default: 'agent-storage' },
+      region: { type: 'string', default: 'us-east-1' },
+    },
+    allowPositionals: true,
+  })
+  const verb = positionals[0]
+  if (verb !== 'seed' && verb !== 'ask') {
+    console.error('usage: npx tsx semantic-memory.ts [--table NAME] [--region REGION] {seed|ask} [question]')
+    process.exit(2)
+  }
+  const question = positionals[1] ?? 'Which seat should I pick for my December trip?'
+
+  const store = buildStore(values.table, values.region)
+  if (verb === 'seed') {
+    await seed(store)
+  } else {
+    await ask(store, question)
+  }
+}
+
+await main()

--- a/examples/session-resume/README.md
+++ b/examples/session-resume/README.md
@@ -61,6 +61,18 @@ parked in bay 42.
 The second process started with nothing in memory. The answer came from the
 snapshot in DynamoDB.
 
+The same flow in TypeScript:
+
+```bash
+npm install @strands-agents/sdk strands-dynamodb-storage tsx
+
+npx tsx session-resume.ts --table agent-storage tell \
+  "My rental car is a blue Nissan Micra, parked in bay 42"
+
+npx tsx session-resume.ts --table agent-storage ask \
+  "What car am I driving and where is it parked?"
+```
+
 ## Why DynamoDB here
 
 Session state sits on the hot path of every agent turn: it is loaded before

--- a/examples/session-resume/session-resume.ts
+++ b/examples/session-resume/session-resume.ts
@@ -1,0 +1,57 @@
+/**
+ * Resume a conversation after a restart, with session state in Amazon DynamoDB.
+ *
+ * Run 1 tells the agent a fact and exits, taking the process (and all in-memory
+ * state) with it. Run 2 constructs a brand-new agent with the same session id
+ * and asks about the fact. The answer comes from the snapshot that
+ * `SessionManager` persisted to DynamoDB, not from anything held in memory.
+ *
+ * Prerequisites:
+ *   - A DynamoDB table with string keys `pk` / `sk` (see README.md).
+ *   - AWS credentials with PutItem/GetItem/DeleteItem/Query on the table and
+ *     InvokeModel on your Bedrock model.
+ *
+ * Usage:
+ *   npx tsx session-resume.ts --table agent-storage tell "My rental car is a blue Nissan Micra"
+ *   npx tsx session-resume.ts --table agent-storage ask "What car am I driving?"
+ */
+
+import { parseArgs } from 'node:util'
+
+import { Agent, SessionManager } from '@strands-agents/sdk'
+import { DynamoDBStorage } from 'strands-dynamodb-storage'
+
+const SESSION_ID = 'session-resume-demo'
+
+/**
+ * Construct an agent whose session state lives in DynamoDB.
+ *
+ * A new process starts with no in-memory state; if a snapshot for
+ * SESSION_ID exists in the table, the session manager restores it here.
+ */
+function buildAgent(table: string, region: string): Agent {
+  const storage = new DynamoDBStorage(table, { region })
+  const session = new SessionManager({ sessionId: SESSION_ID, storage })
+  return new Agent({ sessionManager: session })
+}
+
+async function main(): Promise<void> {
+  const { values, positionals } = parseArgs({
+    options: {
+      table: { type: 'string', default: 'agent-storage' },
+      region: { type: 'string', default: 'us-east-1' },
+    },
+    allowPositionals: true,
+  })
+
+  const [verb, message] = positionals
+  if ((verb !== 'tell' && verb !== 'ask') || message === undefined) {
+    console.error('usage: npx tsx session-resume.ts [--table TABLE] [--region REGION] {tell,ask} message')
+    process.exit(2)
+  }
+
+  const agent = buildAgent(values.table, values.region)
+  await agent.invoke(message)
+}
+
+await main()

--- a/examples/ttl-sessions/README.md
+++ b/examples/ttl-sessions/README.md
@@ -51,6 +51,13 @@ pip install strands-dynamodb-storage boto3
 python ttl_sessions.py --table agent-storage
 ```
 
+Or the TypeScript equivalent:
+
+```bash
+npm install strands-dynamodb-storage @aws-sdk/client-dynamodb @aws-sdk/lib-dynamodb tsx
+npx tsx ttl-sessions.ts --table agent-storage
+```
+
 ```text
 wrote session/cart with ttl_seconds=8, profile/consent with no TTL
 before expiry: read session/cart -> b'3 items, checkout not started'

--- a/examples/ttl-sessions/ttl-sessions.ts
+++ b/examples/ttl-sessions/ttl-sessions.ts
@@ -1,0 +1,84 @@
+/**
+ * Self-expiring agent state with DynamoDB-native TTL.
+ *
+ * Ephemeral state accumulates fast in agent systems: anonymous visitor
+ * sessions, one-off tool scratch space, verification codes. Without a
+ * retention mechanism, someone ends up writing a cleanup job. With this
+ * package, retention is a constructor argument: every write stamps an
+ * epoch-seconds `expireAt` attribute, reads and listings filter items whose
+ * expiry has passed, and DynamoDB physically reaps them in the background at
+ * no request cost.
+ *
+ * The script writes one item with a short TTL and one without, waits out the
+ * expiry, and shows all three views of the aftermath: the expired item is
+ * gone from `read` and `list`, the persistent item is untouched, and the raw
+ * DynamoDB item may still be physically present for a while, which is why the
+ * package filters on read rather than trusting the reaper's timing.
+ *
+ * Prerequisites:
+ *   - A pk/sk table with TTL enabled on `expireAt` (see README.md).
+ *   - Credentials with PutItem/GetItem/DeleteItem/Query on the table.
+ *
+ * Usage:
+ *   npx tsx ttl-sessions.ts --table agent-storage
+ */
+
+import { setTimeout as sleep } from 'node:timers/promises'
+import { parseArgs } from 'node:util'
+
+import { DynamoDBClient, GetItemCommand } from '@aws-sdk/client-dynamodb'
+import { DynamoDBStorage } from 'strands-dynamodb-storage'
+
+const TTL_SECONDS = 8
+
+const encoder = new TextEncoder()
+const decoder = new TextDecoder()
+
+function show(data: Uint8Array | null): string {
+  return data === null ? 'null' : JSON.stringify(decoder.decode(data))
+}
+
+async function main(table: string, region: string): Promise<void> {
+  // ttlSeconds opts the store in to TTL: stamp on write, filter on read/list.
+  const ephemeral = new DynamoDBStorage(table, { region, prefix: 'guest/g1', ttlSeconds: TTL_SECONDS })
+  const durable = new DynamoDBStorage(table, { region, prefix: 'guest/g1' })
+
+  await ephemeral.write('session/cart', encoder.encode('3 items, checkout not started'))
+  await durable.write('profile/consent', encoder.encode('cookie banner accepted v3'))
+  console.log(`wrote session/cart with ttlSeconds=${TTL_SECONDS}, profile/consent with no TTL`)
+
+  const data = await ephemeral.read('session/cart')
+  console.log(`before expiry: read session/cart -> ${show(data)}`)
+  const keys = [...(await ephemeral.list('session/')), ...(await durable.list('profile/'))].sort()
+  console.log(`before expiry: list ->  ${JSON.stringify(keys)}`)
+
+  console.log(`\nwaiting ${TTL_SECONDS + 2}s for expiry...`)
+  await sleep((TTL_SECONDS + 2) * 1000)
+
+  // The store filters the expired item immediately; DynamoDB reaps it later.
+  console.log(`after expiry: read session/cart -> ${show(await ephemeral.read('session/cart'))}`)
+  console.log(`after expiry: list session/ -> ${JSON.stringify(await ephemeral.list('session/'))}`)
+  console.log(`after expiry: read profile/consent -> ${show(await durable.read('profile/consent'))}`)
+
+  // Peek underneath: the raw item can still be physically present until the
+  // background reaper removes it. This is why the package filters on read.
+  const ddb = new DynamoDBClient({ region })
+  const raw = await ddb.send(
+    new GetItemCommand({
+      TableName: table,
+      Key: { pk: { S: 'guest/g1' }, sk: { S: 'session/cart' } },
+    }),
+  )
+  console.log(`raw GetItem still returns an item: ${raw.Item !== undefined} (reaper removes it in the background)`)
+
+  await durable.delete('profile/consent')
+  console.log('\ndemo items cleaned up (expired item left for the reaper)')
+}
+
+const { values } = parseArgs({
+  options: {
+    table: { type: 'string', default: 'agent-storage' },
+    region: { type: 'string', default: 'us-east-1' },
+  },
+})
+await main(values.table, values.region)


### PR DESCRIPTION
## What

TypeScript mirrors for all six examples. Each example directory now carries a TypeScript script alongside the Python one, with the same CLI verbs, flags, and defaults, plus TypeScript run instructions in each README and a dual-language install section in the examples index.

## Why

The package ships both languages from one repository, but every example was Python only. A TypeScript reader had nothing runnable. With the Storage contract fix on main, the mirrors compile clean against @strands-agents/sdk 1.14.0 with no casts.

## Testing done

- Every script executed end to end against real DynamoDB (table with a 1024-dimension vector index) and, for context offload, real S3: session resume recalled a fact in a fresh process, semantic memory answered from seeded memories, multi-tenant isolation assertions passed, TTL expiry filtering and reaper semantics verified, the 1 MB offload round-trip and cleanup verified, and the capstone answered a ticket from its seeded account memory.
- Type-checked strict (NodeNext, ES2022) on @strands-agents/sdk 1.14.0 with the connector built from current main.
