### PR TITLE
chore(release): 0.1.2 for both packages

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "strands-dynamodb-storage"
-version = "0.1.0"
+version = "0.1.2"
 description = "Amazon DynamoDB storage backend for the Strands Agents SDK"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "strands-dynamodb-storage",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "strands-dynamodb-storage",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "Apache-2.0",
       "devDependencies": {
         "@aws-sdk/client-dynamodb": "^3.1104.0",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,7 +1,7 @@
 {
   "name": "strands-dynamodb-storage",
-  "version": "0.1.1",
-  "description": "Amazon DynamoDB storage backend for the Strands Agents SDK \u2014 one Storage implementation for Session Manager, Memory Manager, and any subsystem, with optional S3 offload for large values and an optional native vector-search hook.",
+  "version": "0.1.2",
+  "description": "Amazon DynamoDB storage backend for the Strands Agents SDK — one Storage implementation for Session Manager, Memory Manager, and any subsystem, with optional S3 offload for large values and an optional native vector-search hook.",
   "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.js",


### PR DESCRIPTION
## What

Version bump to 0.1.2 in both packages, aligning npm and PyPI on one version.

## Why

npm 0.1.1 predates the Storage contract conformance fix for @strands-agents/sdk 1.14 (#39); PyPI sits at 0.1.0. Releasing both as 0.1.2 ships the fix and puts the two registries on the same number.

## Testing done

- TypeScript: `npm run check` clean on the bumped tree
- Python: `ruff check`, `mypy src`, `pytest tests` (62 passed, 6 skipped) in a fresh venv with `-e .[dev]`
