### PR TITLE
ci: exclude semver-major updates from grouped dev-dependency PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,9 +37,14 @@ updates:
       # classify PEP 621 pyproject dependencies as development vs production,
       # so dependency-type grouping never matches for pip. Keep these patterns
       # in sync with the dev extra in python/pyproject.toml — anything missed
-      # here silently falls into production-minor.
+      # here silently falls into production-minor. Majors are excluded so a
+      # breaking dev-tool bump arrives individually, matching the convention
+      # stated at the top of this file.
       development-dependencies:
         applies-to: version-updates
+        update-types:
+          - 'minor'
+          - 'patch'
         patterns:
           - 'hatch'
           - 'moto*'
@@ -75,10 +80,16 @@ updates:
       semver-minor-days: 7
       semver-patch-days: 3
     groups:
-      # All development dependencies in one PR.
+      # Development dependency minor + patch bumps in one PR. Majors are
+      # excluded so a breaking dev-tool bump (e.g. a typescript major ahead
+      # of typescript-eslint peer support) arrives individually instead of
+      # poisoning the whole group.
       development-dependencies:
         dependency-type: 'development'
         applies-to: version-updates
+        update-types:
+          - 'minor'
+          - 'patch'
       # Production minor + patch bumps in one PR.
       production-minor:
         dependency-type: 'production'


### PR DESCRIPTION
#41 fails CI because the development-dependencies group carried the typescript 7.0.2 major alongside routine bumps, and @typescript-eslint/eslint-plugin@8.68.0 peers typescript >=4.8.4 <6.1.0, so npm ci fails at ERESOLVE on every node version. The file's own convention says majors arrive as individual PRs, but neither development-dependencies group had the update-types restriction to enforce it.

This restricts both groups (npm and pip) to minor + patch. After this lands, commenting `@dependabot recreate` on #41 regenerates it without the typescript major, which will then arrive as its own PR under the 30-day major cooldown, to be taken when typescript-eslint supports TS 7.