### PR TITLE
docs(examples): AgentCore Runtime example with DynamoDB sessions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 # Ignore the `build/` directory in the package root.
 /build
+
+# Dependency installs (examples/, typescript/).
+node_modules/

--- a/examples/README.md
+++ b/examples/README.md
@@ -16,6 +16,7 @@ directory into your own project and start from there.
 | ⏳ | [ttl-sessions](./ttl-sessions/) | Ephemeral state that expires itself, with no cleanup job to write | Native TTL: stamp on write, filter on read, reap in the background |
 | 📦 | [context-offload](./context-offload/) | A 1 MB value round-trips through the same four-method contract as a 26-byte one | Transparent S3 spillover behind a pointer item |
 | 🎧 | [customer-support](./customer-support/) | The capstone: session resume, semantic recall, and tenant isolation combined in one assistant | One table carrying everything the agent remembers |
+| ☁️ | [agentcore](./agentcore/) | The same wiring hosted on Amazon Bedrock AgentCore Runtime, with sessions keyed by the runtime's session id | Conversation snapshots that survive microVM recycling |
 
 If you are new to the package, run them in that order: each example
 introduces one capability, and the capstone assembles them the way a real
@@ -29,6 +30,7 @@ assistant uses them.
 - "Anonymous sessions are piling up in my table" → [ttl-sessions](./ttl-sessions/)
 - "A tool result blew the 400 KB item limit" → [context-offload](./context-offload/)
 - "Show me all of it working together" → [customer-support](./customer-support/)
+- "I deploy on AgentCore Runtime, where does this fit?" → [agentcore](./agentcore/)
 
 ## Running the examples
 

--- a/examples/agentcore/README.md
+++ b/examples/agentcore/README.md
@@ -1,0 +1,131 @@
+# DynamoDB sessions on Amazon Bedrock AgentCore Runtime
+
+AgentCore Runtime runs each session in an isolated microVM that is recycled
+when the session goes idle: anything the agent holds in memory is gone on the
+next invocation. This example backs the Strands session manager with
+DynamoDB, so the conversation snapshot lives in your own table. The runtime
+supplies a session id on every invocation, the session manager persists the
+conversation under that id, and the same id arriving later restores it,
+whichever microVM serves the request.
+
+## Where this fits next to the AgentCore harness
+
+The AgentCore managed harness is configuration, not code: its state
+persistence is AgentCore Memory, and its bring-your-own option attaches an
+existing AgentCore Memory instance by ARN, not an arbitrary backend. There is
+no route to DynamoDB-backed storage from harness configuration.
+
+The moment you hold Strands code, this example applies. That happens two
+ways: you write the agent yourself (this example), or you run
+[harness export](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/harness-export.html),
+which generates your harness as editable Python on the Strands framework.
+Adding DynamoDB storage to an exported agent is the same three lines this
+example adds: construct the storage, hand it to a session manager keyed by
+the runtime session id, hand the session manager to the agent.
+
+## How it works
+
+The Python variant uses the `bedrock-agentcore` runtime wrapper, which serves
+the required HTTP contract for you and passes the caller's `runtimeSessionId`
+in the request context:
+
+```python
+@app.entrypoint
+def invoke(payload, context):
+    session = SnapshotSessionManager(session_id=context.session_id, storage=storage)
+    agent = Agent(session_manager=session)
+    return {"result": agent(payload.get("prompt", "Hello")).message}
+```
+
+There is no TypeScript equivalent of that wrapper, so the TypeScript variant
+implements the
+[runtime HTTP contract](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-http-protocol-contract.html)
+directly: `POST /invocations` and `GET /ping` on port 8080, with the session
+id arriving in the `X-Amzn-Bedrock-AgentCore-Runtime-Session-Id` header.
+
+## Run it locally
+
+Create a pk/sk table (once):
+
+```bash
+aws dynamodb create-table \
+  --table-name agent-storage \
+  --attribute-definitions AttributeName=pk,AttributeType=S AttributeName=sk,AttributeType=S \
+  --key-schema AttributeName=pk,KeyType=HASH AttributeName=sk,KeyType=RANGE \
+  --billing-mode PAY_PER_REQUEST
+```
+
+Start the agent server:
+
+```bash
+pip install bedrock-agentcore strands-agents strands-dynamodb-storage
+python agentcore_runtime.py
+```
+
+Or the TypeScript equivalent:
+
+```bash
+npm install strands-dynamodb-storage @strands-agents/sdk tsx
+npx tsx agentcore-runtime.ts
+```
+
+Then talk to it, and restart the server between the two calls to prove the
+state lives in DynamoDB rather than in the process:
+
+```bash
+curl -X POST http://localhost:8080/invocations \
+  -H 'Content-Type: application/json' \
+  -H 'X-Amzn-Bedrock-AgentCore-Runtime-Session-Id: verify-session-001' \
+  -d '{"prompt": "Remember this: my rental car is a blue Nissan Micra"}'
+
+# restart the server, then:
+curl -X POST http://localhost:8080/invocations \
+  -H 'Content-Type: application/json' \
+  -H 'X-Amzn-Bedrock-AgentCore-Runtime-Session-Id: verify-session-001' \
+  -d '{"prompt": "What is my rental car?"}'
+```
+
+The second answer comes from a process that never saw the first message
+(response metadata elided):
+
+```text
+{"result": {"role": "assistant", "content": [{"text": "Got it! Your rental car is a **blue Nissan Micra**. I'll remember that for our conversation."}]}}
+{"result": {"role": "assistant", "content": [{"text": "Your rental car is a **blue Nissan Micra**!"}]}}
+```
+
+Locally the session id comes from the header on the curl call; on the
+runtime, the platform sets it from the caller's `runtimeSessionId`.
+
+## Deploy
+
+Deployment to AgentCore Runtime (container build, ECR, role creation) is the
+standard flow documented in
+[deploying Strands agents to AgentCore Runtime](https://strandsagents.com/docs/user-guide/deploy/deploy_to_bedrock_agentcore/python/);
+nothing about it changes for this example. Two additions:
+
+- Set the `AGENT_STORAGE_TABLE` environment variable on the runtime if your
+  table is not named `agent-storage`.
+- Add the storage permissions to the runtime execution role:
+
+```json
+{
+  "Effect": "Allow",
+  "Action": [
+    "dynamodb:PutItem",
+    "dynamodb:GetItem",
+    "dynamodb:DeleteItem",
+    "dynamodb:Query"
+  ],
+  "Resource": "arn:aws:dynamodb:us-east-1:111122223333:table/agent-storage"
+}
+```
+
+The package's [README](../../README.md) carries the additional statements for
+semantic memory, S3 offload, and embedding model invocation if you extend the
+agent with those features.
+
+## Clean up
+
+```bash
+aws dynamodb delete-table --table-name agent-storage
+```

--- a/examples/agentcore/agentcore-runtime.ts
+++ b/examples/agentcore/agentcore-runtime.ts
@@ -1,0 +1,82 @@
+/**
+ * Host a Strands agent on Amazon Bedrock AgentCore Runtime with DynamoDB sessions.
+ *
+ * AgentCore Runtime runs each session in an isolated microVM that is recycled
+ * when the session goes idle, so anything the agent holds in memory is gone on
+ * the next invocation. Backing the session manager with DynamoDB moves the
+ * conversation into your own table: the runtime supplies a session id on every
+ * invocation, the session manager snapshots the conversation under that id,
+ * and the same id arriving later restores it, whichever microVM serves the
+ * request.
+ *
+ * There is no TypeScript runtime wrapper equivalent to the Python
+ * bedrock-agentcore package, so this file implements the runtime's HTTP
+ * contract directly with node:http: POST /invocations and GET /ping on port
+ * 8080, with the session id arriving in the
+ * X-Amzn-Bedrock-AgentCore-Runtime-Session-Id header.
+ *
+ * Prerequisites:
+ *   - A pk/sk table (see README.md).
+ *   - The runtime execution role needs PutItem/GetItem/DeleteItem/Query on it.
+ *
+ * Usage (local):
+ *   npx tsx agentcore-runtime.ts
+ *   curl -X POST http://localhost:8080/invocations \
+ *     -H 'Content-Type: application/json' \
+ *     -d '{"prompt": "Remember this: my rental car is a blue Nissan Micra"}'
+ */
+
+import { createServer } from 'node:http'
+
+import { Agent, SessionManager } from '@strands-agents/sdk'
+import { DynamoDBStorage } from 'strands-dynamodb-storage'
+
+const TABLE = process.env.AGENT_STORAGE_TABLE ?? 'agent-storage'
+const REGION = process.env.AWS_REGION ?? 'us-east-1'
+const SESSION_HEADER = 'x-amzn-bedrock-agentcore-runtime-session-id'
+
+// One storage client for the process; sessions differ only by key prefix,
+// so every session this container serves lands in the same table.
+const storage = new DynamoDBStorage(TABLE, { region: REGION })
+
+const server = createServer(async (req, res) => {
+  // Health check: the runtime polls this to decide the container is ready.
+  if (req.method === 'GET' && req.url === '/ping') {
+    res.writeHead(200, { 'Content-Type': 'application/json' })
+    res.end(JSON.stringify({ status: 'Healthy' }))
+    return
+  }
+
+  if (req.method === 'POST' && req.url === '/invocations') {
+    const chunks: Buffer[] = []
+    for await (const chunk of req) chunks.push(chunk as Buffer)
+
+    try {
+      const payload = JSON.parse(Buffer.concat(chunks).toString() || '{}') as { prompt?: string }
+
+      // The runtime passes the caller's runtimeSessionId in this header.
+      // Locally (plain curl, no session header) there is none, so fall back.
+      const sessionId = (req.headers[SESSION_HEADER] as string | undefined) ?? 'local-dev-session'
+
+      // Snapshot on every turn, restore on the next one. The session manager
+      // is cheap to construct; the durable state lives entirely in DynamoDB.
+      const session = new SessionManager({ sessionId, storage })
+      const agent = new Agent({ sessionManager: session })
+
+      const result = await agent.invoke(payload.prompt ?? 'Hello')
+      res.writeHead(200, { 'Content-Type': 'application/json' })
+      res.end(JSON.stringify({ result: result.lastMessage }))
+    } catch (err) {
+      res.writeHead(500, { 'Content-Type': 'application/json' })
+      res.end(JSON.stringify({ error: String(err) }))
+    }
+    return
+  }
+
+  res.writeHead(404, { 'Content-Type': 'application/json' })
+  res.end(JSON.stringify({ error: 'not found' }))
+})
+
+server.listen(8080, '0.0.0.0', () => {
+  console.log(`agent listening on :8080, sessions stored in table ${TABLE}`)
+})

--- a/examples/agentcore/agentcore-runtime.ts
+++ b/examples/agentcore/agentcore-runtime.ts
@@ -67,8 +67,11 @@ const server = createServer(async (req, res) => {
       res.writeHead(200, { 'Content-Type': 'application/json' })
       res.end(JSON.stringify({ result: result.lastMessage }))
     } catch (err) {
+      // Keep the details in the container log (CloudWatch on the runtime);
+      // the HTTP caller gets a generic failure with no internals.
+      console.error('invocation failed:', err)
       res.writeHead(500, { 'Content-Type': 'application/json' })
-      res.end(JSON.stringify({ error: String(err) }))
+      res.end(JSON.stringify({ error: 'invocation failed' }))
     }
     return
   }

--- a/examples/agentcore/agentcore_runtime.py
+++ b/examples/agentcore/agentcore_runtime.py
@@ -1,0 +1,58 @@
+"""Host a Strands agent on Amazon Bedrock AgentCore Runtime with DynamoDB sessions.
+
+AgentCore Runtime runs each session in an isolated microVM that is recycled
+when the session goes idle, so anything the agent holds in memory is gone on
+the next invocation. Backing the session manager with DynamoDB moves the
+conversation into your own table: the runtime supplies a session id on every
+invocation, the session manager snapshots the conversation under that id, and
+the same id arriving later restores it, whichever microVM serves the request.
+
+The same wiring applies whether you wrote this agent by hand or generated it
+with the AgentCore harness export (see README.md for the harness relationship).
+
+Prerequisites:
+  - A pk/sk table (see README.md).
+  - The runtime execution role needs PutItem/GetItem/DeleteItem/Query on it.
+  - pip install bedrock-agentcore strands-agents strands-dynamodb-storage
+
+Usage (local):
+  python agentcore_runtime.py
+  curl -X POST http://localhost:8080/invocations \
+    -H 'Content-Type: application/json' \
+    -d '{"prompt": "Remember this: my rental car is a blue Nissan Micra"}'
+"""
+
+import os
+
+from bedrock_agentcore.runtime import BedrockAgentCoreApp
+from strands import Agent
+from strands.session import SnapshotSessionManager
+from strands_dynamodb_storage import DynamoDBStorage
+
+TABLE = os.environ.get("AGENT_STORAGE_TABLE", "agent-storage")
+REGION = os.environ.get("AWS_REGION", "us-east-1")
+
+app = BedrockAgentCoreApp()
+
+# One storage client for the process; sessions differ only by key prefix,
+# so every session this container serves lands in the same table.
+storage = DynamoDBStorage(TABLE, region_name=REGION)
+
+
+@app.entrypoint
+def invoke(payload, context):
+    # The runtime passes the caller's runtimeSessionId in the request context.
+    # Locally (plain curl, no session header) there is none, so fall back.
+    session_id = context.session_id or "local-dev-session"
+
+    # Snapshot on every turn, restore on the next one. The session manager is
+    # cheap to construct; the durable state lives entirely in DynamoDB.
+    session = SnapshotSessionManager(session_id=session_id, storage=storage)
+    agent = Agent(session_manager=session)
+
+    result = agent(payload.get("prompt", "Hello"))
+    return {"result": result.message}
+
+
+if __name__ == "__main__":
+    app.run()


### PR DESCRIPTION
## Summary

Adds `examples/agentcore/`: a Strands agent hosted on Amazon Bedrock AgentCore Runtime with the session manager backed by DynamoDB, keyed by the runtime's session id. The README states where the package fits next to the managed harness: harness configuration has no custom storage hook (its bring-your-own option attaches an AgentCore Memory instance by ARN), and harness export generates Strands code, where this wiring applies. Motivated by a re:Post question asking exactly this: https://repost.aws/questions/QUjyW_4sFCTYaJeT8ZKCyd4w

The Python variant uses the `bedrock-agentcore` runtime wrapper; the TypeScript variant implements the runtime HTTP contract (`POST /invocations`, `GET /ping`, port 8080) with `node:http` and reads the session id from `X-Amzn-Bedrock-AgentCore-Runtime-Session-Id`.

Also adds `node_modules/` to `.gitignore`: npm installs it into `examples/` for the TypeScript mirrors and it shows up as untracked noise.

## Testing

- Python variant executed against a real DynamoDB table in us-east-1: two invocations on one session id with a server restart in between; the second process restored the conversation from the table (README sample output is the actual run).
- TypeScript variant passes `tsc --noEmit --strict` against `@strands-agents/sdk` 1.14.0.
- Both variants' imports resolve against the released packages.